### PR TITLE
[chore] Allow wallet.save_seed to create a file if necessary

### DIFF
--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -473,8 +473,9 @@ class Wallet:
         """
         seeds_in_file = {}
 
-        with open(file_path) as f:
-            seeds_in_file = json.load(f)
+        if os.path.exists(file_path):
+            with open(file_path) as f:
+                seeds_in_file = json.load(f)
 
         return seeds_in_file
 


### PR DESCRIPTION
- Allow `wallet.save_seed("seeds.json")` to create a new file if one doesn't already exist.