### PR TITLE
[chore] Fix Get Default Address on Newly Hydrated Wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Contract invocation support.
 
+### Fixed
+
+- Fixed bug in `Wallet` `default_address` property for newly hydrated wallets.
+
 ## [0.0.3] - 2024-09-25
 
 ### Added

--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -606,7 +606,7 @@ class Wallet:
 
         """
         return next(
-            (address for address in self._addresses if address.address_id == address_id),
+            (address for address in self.addresses if address.address_id == address_id),
             None,
         )
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -48,7 +48,7 @@ def wallet_model_factory(address_model_factory):
         network_id="base-sepolia",
         default_address=None,
         feature_set=None,
-        server_signer_status="active_seed",
+        server_signer_status="active_seed"
     ):
         if default_address is None:
             default_address = address_model_factory()


### PR DESCRIPTION
### What changed? Why?
- Fix bug that caused an exception to be raised when getting `wallet.default_address` directly after `wallet.load_seed(...)`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
