### PR TITLE
[chore] Fully Automate Doc Generation via GHA

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -23,6 +23,7 @@ jobs:
 
     - name: Build Sphinx Documentation
       run: |
+        make docs
         cd docs
         make html
 
@@ -32,5 +33,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build/html
         keep_files: false
-        
-      

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ install-deps:
 .PHONY: docs
 docs:
 	sphinx-apidoc -f -o docs/ ./cdp/
+
+.PHONY: local-docs
+local-docs: docs
+	cd docs && make html && open ./_build/html/index.html


### PR DESCRIPTION
### What changed? Why?
- Generate `cdp` docs for new modules via `make docs` during publish docs GHA workflow
- Add `make local-docs` command to run the docs site locally

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
