### PR TITLE
[PSDK-499] Payload Signature Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Contract invocation support.
+- Arbitrary message signing support.
 
 ### Fixed
 

--- a/cdp/__init__.py
+++ b/cdp/__init__.py
@@ -6,6 +6,7 @@ from cdp.balance_map import BalanceMap
 from cdp.cdp import Cdp
 from cdp.contract_invocation import ContractInvocation
 from cdp.faucet_transaction import FaucetTransaction
+from cdp.payload_signature import PayloadSignature
 from cdp.sponsored_send import SponsoredSend
 from cdp.trade import Trade
 from cdp.transaction import Transaction
@@ -30,4 +31,5 @@ __all__ = [
     "FaucetTransaction",
     "Trade",
     "SponsoredSend",
+    "PayloadSignature",
 ]

--- a/cdp/payload_signature.py
+++ b/cdp/payload_signature.py
@@ -1,0 +1,228 @@
+import time
+from collections.abc import Iterator
+from enum import Enum
+
+from cdp import Cdp
+from cdp.client.models.create_payload_signature_request import CreatePayloadSignatureRequest
+from cdp.client.models.payload_signature import PayloadSignature as PayloadSignatureModel
+from cdp.client.models.payload_signature_list import PayloadSignatureList
+
+
+class PayloadSignature:
+    """A representation of a Payload Signature."""
+
+    class Status(Enum):
+        """Enumeration of Payload Signature statuses."""
+
+        PENDING = "pending"
+        SIGNED = "signed"
+        FAILED = "failed"
+
+        @classmethod
+        def terminal_states(cls):
+            """Get the terminal states.
+
+            Returns:
+                List[str]: The terminal states.
+
+            """
+            return [cls.SIGNED, cls.FAILED]
+
+        def __str__(self) -> str:
+            """Return a string representation of the Status."""
+            return self.value
+
+        def __repr__(self) -> str:
+            """Return a string representation of the Status."""
+            return str(self)
+
+    def __init__(self, model: PayloadSignatureModel) -> None:
+        """Initialize the PayloadSignature class.
+
+        Args:
+            model (PayloadSignatureModel): The model representing the paylaod signature.
+
+        """
+        if not isinstance(model, PayloadSignatureModel):
+            raise TypeError("model must be of type PayloadSignatureModel")
+
+        self._model = model
+
+    @property
+    def payload_signature_id(self) -> str:
+        """Get the payload signature ID.
+
+        Returns:
+            str: The payload signature ID.
+
+        """
+        return self._model.payload_signature_id
+
+    @property
+    def wallet_id(self) -> str:
+        """Get the wallet ID.
+
+        Returns:
+            str: The wallet ID.
+
+        """
+        return self._model.wallet_id
+
+    @property
+    def address_id(self) -> str:
+        """Get the address ID.
+
+        Returns:
+            str: The address ID.
+
+        """
+        return self._model.address_id
+
+    @property
+    def unsigned_payload(self) -> str:
+        """Get the unsigned payload.
+
+        Returns:
+            str: The unsigned payload.
+
+        """
+        return self._model.unsigned_payload
+
+    @property
+    def signature(self) -> str:
+        """Get the signature.
+
+        Returns:
+            str: The signature.
+
+        """
+        return self._model.signature
+
+    @property
+    def status(self) -> Status:
+        """Get the status.
+
+        Returns:
+            PayloadSignature.Status: The status.
+
+        """
+        return self.Status(self._model.status)
+
+    @property
+    def terminal_state(self) -> bool:
+        """Check if the Transaction is in a terminal state.
+
+        Returns:
+            bool: Whether the paylaod signature is in a terminal state.
+
+        """
+        return self.status in self.Status.terminal_states()
+
+    def reload(self) -> None:
+        """Reload the payload signature."""
+        model = Cdp.api_clients.addresses.get_payload_signature(
+            self.wallet_id, self.address_id, self.payload_signature_id
+        )
+        self._model = model
+
+    def wait(
+        self, interval_seconds: float = 0.2, timeout_seconds: float = 20
+    ) -> "PayloadSignature":
+        """Wait for the payload signature to complete.
+
+        Args:
+            interval_seconds (float): The interval seconds.
+            timeout_seconds (float): The timeout seconds.
+
+        Returns:
+            PayloadSignature: The payload signature.
+
+        """
+        start_time = time.time()
+
+        while not self.terminal_state:
+            self.reload()
+
+            if time.time() - start_time > timeout_seconds:
+                raise TimeoutError("Timed out waiting for PayloadSignature to be signed")
+
+            time.sleep(interval_seconds)
+
+        return self
+
+    @classmethod
+    def create(
+        cls, wallet_id: str, address_id: str, unsigned_payload: str, signature: str | None = None
+    ) -> "PayloadSignature":
+        """Create a payload signature.
+
+        Args:
+            wallet_id (str): The wallet ID.
+            address_id (str): The address ID.
+            unsigned_payload (str): The unsigned payload.
+            signature (Optional[str]): The signature.
+
+        Returns:
+            PayloadSignature: The payload signature.
+
+        Raises:
+            Exception: If there's an error creating the payload signature..
+
+        """
+        create_payload_signature_request_dict = {"unsigned_payload": unsigned_payload}
+
+        if signature is not None:
+            create_payload_signature_request_dict["signature"] = signature
+
+        create_payload_signature_request = CreatePayloadSignatureRequest.from_dict(
+            create_payload_signature_request_dict
+        )
+
+        model = Cdp.api_clients.addresses.create_payload_signature(
+            wallet_id=wallet_id,
+            address_id=address_id,
+            create_payload_signature_request=create_payload_signature_request,
+        )
+
+        return cls(model)
+
+    @classmethod
+    def list(cls, wallet_id: str, address_id: str) -> Iterator["PayloadSignature"]:
+        """List payload signatures.
+
+        Args:
+            wallet_id (str): The wallet ID.
+            address_id (str): The address ID.
+
+        Returns:
+            Iterator[Payload]: An iterator of payload signatures.
+
+        Raises:
+            Exception: If there's an error listing the payload signatures.
+
+        """
+        page = None
+        while True:
+            response: PayloadSignatureList = Cdp.api_clients.addresses.list_payload_signatures(
+                wallet_id=wallet_id, address_id=address_id, limit=100, page=page
+            )
+
+            for payload_signature_model in response.data:
+                yield cls(payload_signature_model)
+
+            if not response.has_more:
+                break
+
+            page = response.next_page
+
+    def __str__(self) -> str:
+        """Get a string representation of the payload signature."""
+        return (
+            f"PayloadSignature: (payload_signature_id: {self.payload_signature_id}, wallet_id: {self.wallet_id}, "
+            f"address_id: {self.address_id}, unsigned_payload: {self.unsigned_payload}, signature: {self.signature}, "
+            f"status: {self.status})"
+        )
+
+    def __repr__(self) -> str:
+        """Get a string representation of the payload signature."""
+        return str(self)

--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -28,6 +28,7 @@ from cdp.client.models.wallet import Wallet as WalletModel
 from cdp.client.models.wallet_list import WalletList
 from cdp.contract_invocation import ContractInvocation
 from cdp.faucet_transaction import FaucetTransaction
+from cdp.payload_signature import PayloadSignature
 from cdp.trade import Trade
 from cdp.wallet_address import WalletAddress
 from cdp.wallet_data import WalletData
@@ -420,6 +421,22 @@ class Wallet:
         )
 
         return invocation
+
+    def sign_payload(self, unsigned_payload: str) -> PayloadSignature:
+        """Sign the given unsigned payload.
+
+        Args:
+            unsigned_payload (str): The unsigned payload.
+
+        Returns:
+            PayloadSignature: The payload signature object.
+
+
+        """
+        if self.default_address is None:
+            raise ValueError("Default address does not exist")
+
+        return self.default_address.sign_payload(unsigned_payload)
 
     @property
     def default_address(self) -> WalletAddress | None:

--- a/tests/test_payload_signature.py
+++ b/tests/test_payload_signature.py
@@ -1,0 +1,205 @@
+from unittest.mock import ANY, Mock, call, patch
+
+import pytest
+
+from cdp.client.models.payload_signature import PayloadSignature as PayloadSignatureModel
+from cdp.payload_signature import PayloadSignature
+
+
+@pytest.fixture
+def payload_signature_model_factory():
+    """Create and return a factory for creating PayloadSignatureModel fixtures."""
+
+    def _create_payload_signature_model(status="signed"):
+        payload_signature_model = PayloadSignatureModel(
+            payload_signature_id="test-payload-signature-id",
+            address_id="0xaddressid",
+            wallet_id="test-wallet-id",
+            unsigned_payload="0xunsignedpayload",
+            signature="0xsignature" if status == "signed" else None,
+            status=status,
+        )
+
+        return payload_signature_model
+
+    return _create_payload_signature_model
+
+
+@pytest.fixture
+def payload_signature_factory(payload_signature_model_factory):
+    """Create and return a factory for creating PayloadSignature fixtures."""
+
+    def _create_payload_signature(status="signed"):
+        payload_signature_model = payload_signature_model_factory(status)
+        return PayloadSignature(payload_signature_model)
+
+    return _create_payload_signature
+
+
+def test_payload_signature_initialization(payload_signature_factory):
+    """Test the initialization of a PayloadSignature object."""
+    payload_signature = payload_signature_factory()
+    assert isinstance(payload_signature, PayloadSignature)
+
+
+def test_payload_signuatre_properties(payload_signature_factory):
+    """Test the properties of a PayloadSignature object."""
+    payload_signature = payload_signature_factory()
+    assert payload_signature.payload_signature_id == "test-payload-signature-id"
+    assert payload_signature.address_id == "0xaddressid"
+    assert payload_signature.wallet_id == "test-wallet-id"
+    assert payload_signature.unsigned_payload == "0xunsignedpayload"
+    assert payload_signature.signature == "0xsignature"
+    assert payload_signature.status.value == "signed"
+
+
+@patch("cdp.Cdp.api_clients")
+def test_create_unsigned_payload_signature(mock_api_clients, payload_signature_model_factory):
+    """Test the creation of a PayloadSignature object."""
+    mock_create_payload_signature = Mock(return_value=payload_signature_model_factory("pending"))
+    mock_api_clients.addresses.create_payload_signature = mock_create_payload_signature
+
+    payload_signature = PayloadSignature.create(
+        wallet_id="test-wallet-id",
+        address_id="0xaddressid",
+        unsigned_payload="0xunsignedpayload",
+        signature="0xsignature",
+    )
+
+    assert isinstance(payload_signature, PayloadSignature)
+    mock_create_payload_signature.assert_called_once_with(
+        wallet_id="test-wallet-id", address_id="0xaddressid", create_payload_signature_request=ANY
+    )
+
+    create_payload_signature_request = mock_create_payload_signature.call_args[1][
+        "create_payload_signature_request"
+    ]
+    assert create_payload_signature_request.unsigned_payload == "0xunsignedpayload"
+
+
+@patch("cdp.Cdp.api_clients")
+def test_create_payload_signature(mock_api_clients, payload_signature_model_factory):
+    """Test the creation of a PayloadSignature object."""
+    mock_create_payload_signature = Mock(return_value=payload_signature_model_factory())
+    mock_api_clients.addresses.create_payload_signature = mock_create_payload_signature
+
+    payload_signature = PayloadSignature.create(
+        wallet_id="test-wallet-id",
+        address_id="0xaddressid",
+        unsigned_payload="0xunsignedpayload",
+        signature="0xsignature",
+    )
+
+    assert isinstance(payload_signature, PayloadSignature)
+    mock_create_payload_signature.assert_called_once_with(
+        wallet_id="test-wallet-id", address_id="0xaddressid", create_payload_signature_request=ANY
+    )
+
+    create_payload_signature_request = mock_create_payload_signature.call_args[1][
+        "create_payload_signature_request"
+    ]
+    assert create_payload_signature_request.unsigned_payload == "0xunsignedpayload"
+    assert create_payload_signature_request.signature == "0xsignature"
+
+
+@patch("cdp.Cdp.api_clients")
+def test_list_payload_signatures(mock_api_clients, payload_signature_model_factory):
+    """Test the listing of payload signatures."""
+    mock_list_payload_signatures = Mock()
+    mock_list_payload_signatures.return_value = Mock(
+        data=[payload_signature_model_factory()], has_more=False
+    )
+    mock_api_clients.addresses.list_payload_signatures = mock_list_payload_signatures
+
+    payload_signatures = PayloadSignature.list("test-wallet-id", "0xaddressid")
+    assert len(list(payload_signatures)) == 1
+    assert all(isinstance(p, PayloadSignature) for p in payload_signatures)
+    mock_list_payload_signatures.assert_called_once_with(
+        wallet_id="test-wallet-id", address_id="0xaddressid", limit=100, page=None
+    )
+
+
+@patch("cdp.Cdp.api_clients")
+def test_reload_payload_signature(mock_api_clients, payload_signature_factory):
+    """Test the reloading of a payload signature."""
+    payload_signature = payload_signature_factory("pending")
+    signed_payload_signature = payload_signature_factory()
+    mock_get_payload_signature = Mock(return_value=signed_payload_signature._model)
+    mock_api_clients.addresses.get_payload_signature = mock_get_payload_signature
+
+    payload_signature.reload()
+    mock_get_payload_signature.assert_called_once_with(
+        payload_signature.wallet_id,
+        payload_signature.address_id,
+        payload_signature.payload_signature_id,
+    )
+    assert payload_signature.status.value == "signed"
+
+
+@patch("cdp.Cdp.api_clients")
+@patch("cdp.payload_signature.time.sleep")
+@patch("cdp.payload_signature.time.time")
+def test_wait_for_payload_signature(
+    mock_time, mock_sleep, mock_api_clients, payload_signature_factory
+):
+    """Test the waiting for a PayloadSignature object to be signed."""
+    pending_payload_signature = payload_signature_factory("pending")
+    signed_payload_signature = payload_signature_factory()
+    mock_get_payload_signature = Mock()
+    mock_api_clients.addresses.get_payload_signature = mock_get_payload_signature
+    mock_get_payload_signature.side_effect = [
+        pending_payload_signature._model,
+        signed_payload_signature._model,
+    ]
+
+    mock_time.side_effect = [0, 0.2, 0.4]
+
+    result = pending_payload_signature.wait(interval_seconds=0.2, timeout_seconds=1)
+
+    assert result.status.value == "signed"
+    mock_get_payload_signature.assert_called_with(
+        pending_payload_signature.wallet_id,
+        pending_payload_signature.address_id,
+        pending_payload_signature.payload_signature_id,
+    )
+    assert mock_get_payload_signature.call_count == 2
+    mock_sleep.assert_has_calls([call(0.2)] * 2)
+    assert mock_time.call_count == 3
+
+
+@patch("cdp.Cdp.api_clients")
+@patch("cdp.payload_signature.time.sleep")
+@patch("cdp.payload_signature.time.time")
+def test_wait_for_payload_signature_timeout(
+    mock_time, mock_sleep, mock_api_clients, payload_signature_factory
+):
+    """Test the waiting for a PayloadSignature object to be signed with a timeout."""
+    pending_payload_signature = payload_signature_factory("pending")
+    mock_get_payload_signature = Mock(return_value=pending_payload_signature._model)
+    mock_api_clients.addresses.get_payload_signature = mock_get_payload_signature
+
+    mock_time.side_effect = [0, 0.5, 1.0, 1.5, 2.0, 2.5]
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for PayloadSignature to be signed"):
+        pending_payload_signature.wait(interval_seconds=0.5, timeout_seconds=2)
+
+    assert mock_get_payload_signature.call_count == 5
+    mock_sleep.assert_has_calls([call(0.5)] * 4)
+    assert mock_time.call_count == 6
+
+
+def test_payload_signature_str_representation(payload_signature_factory):
+    """Test the string representation of a PayloadSignature object."""
+    payload_signature = payload_signature_factory()
+    expected_str = (
+        f"PayloadSignature: (payload_signature_id: {payload_signature.payload_signature_id}, wallet_id: {payload_signature.wallet_id}, "
+        f"address_id: {payload_signature.address_id}, unsigned_payload: {payload_signature.unsigned_payload}, signature: {payload_signature.signature}, "
+        f"status: {payload_signature.status})"
+    )
+    assert str(payload_signature) == expected_str
+
+
+def test_payload_signature_repr(payload_signature_factory):
+    """Test the representation of a PayloadSignature object."""
+    payload_signature = payload_signature_factory()
+    assert repr(payload_signature) == str(payload_signature)


### PR DESCRIPTION
### What changed? Why?
- Arbitrary message signing support via `wallet.sign_payload(...)`
- Following up with helpers to hash EIP-191 and EIP-712 data messages!

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
