### PR TITLE
Adds source and source type for better usage monitoring

### DIFF
--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -56,8 +56,8 @@ class Cdp:
         debugging: bool = False,
         base_path: str = "https://api.cdp.coinbase.com/platform",
         max_network_retries: int = 3,
-        source: str | None = None,
-        source_version: str | None = None,
+        source: str = SDK_DEFAULT_SOURCE,
+        source_version: str = __version__,
     ) -> None:
         """Configure the CDP SDK.
 
@@ -79,11 +79,6 @@ class Cdp:
         cls.base_path = base_path
         cls.max_network_retries = max_network_retries
 
-        if source is None:
-            source = SDK_DEFAULT_SOURCE
-        if source_version is None:
-            source_version = __version__
-
         cdp_client = CdpApiClient(
             api_key_name,
             private_key,
@@ -103,8 +98,8 @@ class Cdp:
         debugging: bool = False,
         base_path: str = "https://api.cdp.coinbase.com/platform",
         max_network_retries: int = 3,
-        source: str | None = None,
-        source_version: str | None = None,
+        source: str = SDK_DEFAULT_SOURCE,
+        source_version: str = __version__,
     ) -> None:
         """Configure the CDP SDK from a JSON file.
 

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -1,8 +1,10 @@
 import json
 import os
 
+from cdp import __version__
 from cdp.api_clients import ApiClients
 from cdp.cdp_api_client import CdpApiClient
+from cdp.constants import SDK_DEFAULT_SOURCE
 from cdp.errors import InvalidConfigurationError
 
 
@@ -54,8 +56,8 @@ class Cdp:
         debugging: bool = False,
         base_path: str = "https://api.cdp.coinbase.com/platform",
         max_network_retries: int = 3,
-        source: str = "",
-        source_version: str = "",
+        source: str | None = None,
+        source_version: str | None = None,
     ) -> None:
         """Configure the CDP SDK.
 
@@ -66,8 +68,8 @@ class Cdp:
             debugging (bool): Whether debugging is enabled. Defaults to False.
             base_path (str): The base URL for the CDP API. Defaults to "https://api.cdp.coinbase.com/platform".
             max_network_retries (int): The maximum number of network retries. Defaults to 3.
-            source (str): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
-            source_version (str): The version of the source package.
+            source (Optional[str]): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
+            source_version (Optional[str]): The version of the source package.
 
         """
         cls.api_key_name = api_key_name
@@ -77,8 +79,19 @@ class Cdp:
         cls.base_path = base_path
         cls.max_network_retries = max_network_retries
 
+        if source is None:
+            source = SDK_DEFAULT_SOURCE
+        if source_version is None:
+            source_version = __version__
+
         cdp_client = CdpApiClient(
-            api_key_name, private_key, base_path, debugging, max_network_retries, source, source_version
+            api_key_name,
+            private_key,
+            base_path,
+            debugging,
+            max_network_retries,
+            source,
+            source_version,
         )
         cls.api_clients = ApiClients(cdp_client)
 
@@ -90,8 +103,8 @@ class Cdp:
         debugging: bool = False,
         base_path: str = "https://api.cdp.coinbase.com/platform",
         max_network_retries: int = 3,
-        source: str = "",
-        source_version: str = "",
+        source: str | None = None,
+        source_version: str | None = None,
     ) -> None:
         """Configure the CDP SDK from a JSON file.
 
@@ -101,8 +114,8 @@ class Cdp:
             debugging (bool): Whether debugging is enabled. Defaults to False.
             base_path (str): The base URL for the CDP API. Defaults to "https://api.cdp.coinbase.com/platform".
             max_network_retries (int): The maximum number of network retries. Defaults to 3.
-            source (str): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
-            source_version (str): The version of the source package.
+            source (Optional[str]): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
+            source_version (Optional[str]): The version of the source package.
 
         Raises:
             InvalidConfigurationError: If the JSON file is missing the 'api_key_name' or 'private_key'.

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -54,6 +54,8 @@ class Cdp:
         debugging: bool = False,
         base_path: str = "https://api.cdp.coinbase.com/platform",
         max_network_retries: int = 3,
+        source: str = "",
+        source_version: str = "",
     ) -> None:
         """Configure the CDP SDK.
 
@@ -64,6 +66,8 @@ class Cdp:
             debugging (bool): Whether debugging is enabled. Defaults to False.
             base_path (str): The base URL for the CDP API. Defaults to "https://api.cdp.coinbase.com/platform".
             max_network_retries (int): The maximum number of network retries. Defaults to 3.
+            source (str): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
+            source_version (str): The version of the source package.
 
         """
         cls.api_key_name = api_key_name
@@ -74,7 +78,7 @@ class Cdp:
         cls.max_network_retries = max_network_retries
 
         cdp_client = CdpApiClient(
-            api_key_name, private_key, base_path, debugging, max_network_retries
+            api_key_name, private_key, base_path, debugging, max_network_retries, source, source_version
         )
         cls.api_clients = ApiClients(cdp_client)
 
@@ -86,6 +90,8 @@ class Cdp:
         debugging: bool = False,
         base_path: str = "https://api.cdp.coinbase.com/platform",
         max_network_retries: int = 3,
+        source: str = "",
+        source_version: str = "",
     ) -> None:
         """Configure the CDP SDK from a JSON file.
 
@@ -95,6 +101,8 @@ class Cdp:
             debugging (bool): Whether debugging is enabled. Defaults to False.
             base_path (str): The base URL for the CDP API. Defaults to "https://api.cdp.coinbase.com/platform".
             max_network_retries (int): The maximum number of network retries. Defaults to 3.
+            source (str): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
+            source_version (str): The version of the source package.
 
         Raises:
             InvalidConfigurationError: If the JSON file is missing the 'api_key_name' or 'private_key'.
@@ -108,7 +116,6 @@ class Cdp:
                 raise InvalidConfigurationError("Invalid JSON format: Missing 'api_key_name'")
             if not private_key:
                 raise InvalidConfigurationError("Invalid JSON format: Missing 'private_key'")
-
             cls.configure(
                 api_key_name,
                 private_key,
@@ -116,4 +123,6 @@ class Cdp:
                 debugging,
                 base_path,
                 max_network_retries,
+                source,
+                source_version,
             )

--- a/cdp/cdp_api_client.py
+++ b/cdp/cdp_api_client.py
@@ -14,6 +14,7 @@ from cdp.client.api_response import ApiResponse
 from cdp.client.api_response import T as ApiResponseT  # noqa: N811
 from cdp.client.configuration import Configuration
 from cdp.client.exceptions import ApiException
+from cdp.constants import SDK
 from cdp.errors import ApiError, InvalidAPIKeyFormatError
 
 
@@ -27,6 +28,8 @@ class CdpApiClient(ApiClient):
         host: str = "https://api.cdp.coinbase.com/platform",
         debugging: bool = False,
         max_network_retries: int = 3,
+        source: str = SDK,
+        source_version: str = __version__,
     ):
         """Initialize the CDP API Client.
 
@@ -36,6 +39,8 @@ class CdpApiClient(ApiClient):
             host (str, optional): The base URL for the API. Defaults to "https://api.cdp.coinbase.com/platform".
             debugging (bool): Whether debugging is enabled.
             max_network_retries (int): The maximum number of network retries. Defaults to 3.
+            source (str): Specifies whether the sdk is being used directly or if it's an Agentkit extension.
+            source_version (str): The version of the source package.
 
         """
         retry_strategy = self._get_retry_strategy(max_network_retries)
@@ -44,6 +49,8 @@ class CdpApiClient(ApiClient):
         self._api_key = api_key
         self._private_key = private_key
         self._debugging = debugging
+        self._source = source
+        self._source_version = source_version
 
     @property
     def api_key(self) -> str:
@@ -208,7 +215,7 @@ class CdpApiClient(ApiClient):
         return "".join(random.choices("0123456789", k=16))
 
     def _get_correlation_data(self) -> str:
-        """Return encoded correlation data including the SDK version and language.
+        """Return encoded correlation data including the SDK version, language, source.
 
         Returns:
             str: The correlation data.
@@ -217,6 +224,8 @@ class CdpApiClient(ApiClient):
         data = {
             "sdk_version": __version__,
             "sdk_language": "python",
+            "source": self._source,
+            "source_version": self._source_version,
         }
         return ",".join(f"{key}={value}" for key, value in data.items())
 

--- a/cdp/cdp_api_client.py
+++ b/cdp/cdp_api_client.py
@@ -215,7 +215,7 @@ class CdpApiClient(ApiClient):
         return "".join(random.choices("0123456789", k=16))
 
     def _get_correlation_data(self) -> str:
-        """Return encoded correlation data including the SDK version, language, source.
+        """Return encoded correlation data including the SDK version, language, and source.
 
         Returns:
             str: The correlation data.

--- a/cdp/cdp_api_client.py
+++ b/cdp/cdp_api_client.py
@@ -14,7 +14,7 @@ from cdp.client.api_response import ApiResponse
 from cdp.client.api_response import T as ApiResponseT  # noqa: N811
 from cdp.client.configuration import Configuration
 from cdp.client.exceptions import ApiException
-from cdp.constants import SDK
+from cdp.constants import SDK_DEFAULT_SOURCE
 from cdp.errors import ApiError, InvalidAPIKeyFormatError
 
 
@@ -28,7 +28,7 @@ class CdpApiClient(ApiClient):
         host: str = "https://api.cdp.coinbase.com/platform",
         debugging: bool = False,
         max_network_retries: int = 3,
-        source: str = SDK,
+        source: str = SDK_DEFAULT_SOURCE,
         source_version: str = __version__,
     ):
         """Initialize the CDP API Client.

--- a/cdp/constants.py
+++ b/cdp/constants.py
@@ -1,0 +1,3 @@
+"""Specifies package level constants used throughotu the package."""
+
+SDK = "sdk"

--- a/cdp/constants.py
+++ b/cdp/constants.py
@@ -1,3 +1,4 @@
-"""Specifies package level constants used throughotu the package."""
+"""Specifies package level constants used throughout the package."""
 
-SDK = "sdk"
+# SDK_DEFAULT_SOURCE (str): Denotes the default source for the Python SDK.
+SDK_DEFAULT_SOURCE = "sdk"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,14 +1,31 @@
-
 from cdp import __version__
+from cdp.cdp import Cdp
 from cdp.cdp_api_client import CdpApiClient
-from cdp.constants import SDK
+from cdp.constants import SDK_DEFAULT_SOURCE
 
 
 def test_api_client_get_correlation_data():
     """Tests _get_correlation_data from the CdpApiClient."""
     cdp_api_client = CdpApiClient(
-        api_key = "test",
-        private_key = "test",
+        api_key="test",
+        private_key="test",
     )
-    expected_result = f"""sdk_version={__version__},sdk_language=python,source={SDK},source_version={__version__}"""
+    expected_result = f"""sdk_version={__version__},sdk_language=python,source={SDK_DEFAULT_SOURCE},source_version={__version__}"""
     assert cdp_api_client._get_correlation_data() == expected_result
+
+    cdp_api_client2 = CdpApiClient(
+        api_key="test",
+        private_key="test",
+        host="https://api.cdp.coinbase.com/platform",
+        debugging=False,
+        max_network_retries=3,
+        source="test",
+        source_version="test_ver",
+    )
+    expected_result2 = (
+        f"""sdk_version={__version__},sdk_language=python,source=test,source_version=test_ver"""
+    )
+    assert cdp_api_client2._get_correlation_data() == expected_result2
+
+    Cdp.configure(api_key_name="test", private_key="test")
+    assert Cdp.api_clients._cdp_client._get_correlation_data() == expected_result

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -29,3 +29,6 @@ def test_api_client_get_correlation_data():
 
     Cdp.configure(api_key_name="test", private_key="test")
     assert Cdp.api_clients._cdp_client._get_correlation_data() == expected_result
+
+    Cdp.configure(api_key_name="test", private_key="test", source="test", source_version="test_ver")
+    assert Cdp.api_clients._cdp_client._get_correlation_data() == expected_result2

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,14 @@
+
+from cdp import __version__
+from cdp.cdp_api_client import CdpApiClient
+from cdp.constants import SDK
+
+
+def test_api_client_get_correlation_data():
+    """Tests _get_correlation_data from the CdpApiClient."""
+    cdp_api_client = CdpApiClient(
+        api_key = "test",
+        private_key = "test",
+    )
+    expected_result = f"""sdk_version={__version__},sdk_language=python,source={SDK},source_version={__version__}"""
+    assert cdp_api_client._get_correlation_data() == expected_result


### PR DESCRIPTION
### What changed? Why?

This PR does the following: 

1. Adds `source` and `source_version` to the `Cdp` and `CdpApiClient` to be able to differentiate between pure sdk usage and Agentkit extensions. 
2. Tracks this information in string returned by the `_get_correlation_data` method for `CdpApiClient` by adding `source=sdk `and `source_version=__version__`
3. Adds a unit test for the above method.


#### Qualified Impact
If there was an error, `_get_correlation_data` would not work, but this method is tested. To fix the error, we should rollback. 
