### PR TITLE
Fix Asset from_model bug to use passed in asset_id when initializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+### Fixed
 - Fix bug in `Asset.from_model` where passed in asset ID was not used when creating a gwei or wei asset.
 
 ## [0.10.3] - 2024-11-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix bug in `Asset.from_model` where passed in asset ID was not used when creating a gwei or wei asset.
+
 ## [0.10.3] - 2024-11-07
 
 ### Added

--- a/cdp/asset.py
+++ b/cdp/asset.py
@@ -52,7 +52,7 @@ class Asset:
 
         return cls(
             network_id=model.network_id,
-            asset_id=model.asset_id,
+            asset_id=asset_id or model.asset_id,
             contract_address=model.contract_address,
             decimals=decimals,
         )

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -32,6 +32,7 @@ def test_asset_from_model_with_gwei(asset_model_factory):
     asset_model = asset_model_factory(asset_id="eth", decimals=18)
 
     asset = Asset.from_model(asset_model, asset_id="gwei")
+    assert asset.asset_id == "gwei"
     assert asset.decimals == 9
 
 
@@ -40,6 +41,7 @@ def test_asset_from_model_with_wei(asset_model_factory):
     asset_model = asset_model_factory(asset_id="eth", decimals=18)
 
     asset = Asset.from_model(asset_model, asset_id="wei")
+    assert asset.asset_id == "wei"
     assert asset.decimals == 0
 
 

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -42,7 +42,7 @@ def test_balance_from_model_with_asset_id(balance_model_factory):
     balance = Balance.from_model(balance_model, asset_id="gwei")
     assert balance.amount == Decimal("1000000000")
     assert isinstance(balance.asset, Asset)
-    assert balance.asset.asset_id == "eth"
+    assert balance.asset.asset_id == "gwei"
     assert balance.asset_id == "gwei"
 
 


### PR DESCRIPTION
### What changed? Why?
- Right now, we use the passed in asset_id to set the decimals correctly. We don't however set the asset_id. Ruby SDK does this correctly:

```
        new(
          network: Coinbase.to_sym(asset_model.network_id),
          asset_id: asset_id || Coinbase.to_sym(asset_model.asset_id),
          address_id: asset_model.contract_address,
          decimals: decimals
        )
```

### Testing
Updated unit tests to assert the asset ID in test_asset.py, which confirmed the bug. Tests now pass. Had to also update test_balance.py which actually asserted that the asset_id stored on a balance was different than the model asset, which was wrong.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
