### PR TITLE
Fix quote fund to properly pass in normalized amount

### DIFF
--- a/cdp/wallet_address.py
+++ b/cdp/wallet_address.py
@@ -361,7 +361,7 @@ class WalletAddress(Address):
 
         return FundQuote.create(
             address_id=self.address_id,
-            amount=str(normalized_amount),
+            amount=normalized_amount,
             asset_id=asset_id,
             network_id=self.network_id,
             wallet_id=self.wallet_id,

--- a/tests/test_wallet_address.py
+++ b/tests/test_wallet_address.py
@@ -1076,7 +1076,7 @@ def test_quote_fund(mock_fund_quote, wallet_address_factory):
     assert isinstance(fund_quote, FundQuote)
     mock_fund_quote.create.assert_called_once_with(
         address_id=wallet_address.address_id,
-        amount="1.0",
+        amount=Decimal("1.0"),
         asset_id="eth",
         network_id=wallet_address.network_id,
         wallet_id=wallet_address.wallet_id,
@@ -1095,7 +1095,7 @@ def test_quote_fund_api_error(mock_fund_quote, wallet_address_factory):
 
     mock_fund_quote.create.assert_called_once_with(
         address_id=wallet_address.address_id,
-        amount="1.0",
+        amount=Decimal("1.0"),
         asset_id="eth",
         network_id=wallet_address.network_id,
         wallet_id=wallet_address.wallet_id,


### PR DESCRIPTION
### What changed? Why?
- Forgot to merge this in my earlier PR, this fixes quote to correctly use the normalized decimal amount

