### PR TITLE
fix: Use Poetry Virtualenv during Docs Build GHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Release to PyPI
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         make docs
         cd docs
-        make html
+        poetry run make html
 
     - name: Deploy to Github Pages
       uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
### What changed? Why?
- Trigger PyPI release on tag release
- Use poetry virtualenv for GHA to build docs

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
