### PR TITLE
feat: wallet address invoke contract input validation

### DIFF
--- a/cdp/wallet_address.py
+++ b/cdp/wallet_address.py
@@ -194,8 +194,14 @@ class WalletAddress(Address):
         Returns:
             ContractInvocation: The contract invocation object.
 
+        Raises:
+            ValueError: If an amount is provided and an asset_id does not exist
+
         """
         normalized_amount = Decimal(amount) if amount else Decimal("0")
+
+        if normalized_amount > 0.0 and not asset_id:
+            raise ValueError("Asset ID is required for contract invocation if an amount is provided")
 
         if amount and asset_id:
             self._ensure_sufficient_balance(normalized_amount, asset_id)

--- a/tests/test_wallet_address.py
+++ b/tests/test_wallet_address.py
@@ -474,8 +474,32 @@ def test_invoke_contract(
 @patch("cdp.wallet_address.ContractInvocation")
 @patch("cdp.Cdp.api_clients")
 @patch("cdp.Cdp.use_server_signer", False)
+def test_invoke_contract_with_invalid_input(
+    mock_api_clients, mock_contract_invocation, wallet_address_factory, balance_model_factory
+):
+    """Test the invoke_contract method raises an error with invalid input."""
+    wallet_address_with_key = wallet_address_factory(key=True)
+    balance_model = balance_model_factory(
+        amount="5000000000000000000", network_id="base-sepolia", asset_id="eth", decimals=18
+    )
+
+    with pytest.raises(Exception, match="Asset ID is required for contract invocation if an amount is provided"):
+        wallet_address_with_key.invoke_contract(
+            contract_address="0xcontractaddress",
+            method="testMethod",
+            abi=[{"abi": "data"}],
+            args={"arg1": "value1"},
+            amount=Decimal("1"),
+        )
+
+
+@ patch("cdp.wallet_address.ContractInvocation")
+@ patch("cdp.Cdp.api_clients")
+@ patch("cdp.Cdp.use_server_signer", False)
 def test_invoke_contract_api_error(
     mock_api_clients, mock_contract_invocation, wallet_address_factory, balance_model_factory
+
+
 ):
     """Test the invoke_contract method raises an error when the create API call fails."""
     wallet_address_with_key = wallet_address_factory(key=True)


### PR DESCRIPTION
### What changed? Why?

implementing input validation for amount and asset_id.

if an amount is provided, the corresponding asset_id must also be provided

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
