### PR TITLE
feat(PSDK-670): Support external wallet imports, wallet imports from CDP Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Add `network_id` to `WalletData` so that it is saved with the seed data and surfaced via the export function
+- Add ability to import external wallets into CDP via a BIP-39 mnemonic phrase, as a 1-of-1 wallet
+- Add ability to import WalletData files exported by the NodeJS CDP SDK
+- Deprecate `Wallet.load_seed` method in favor of `Wallet.load_seed_from_file`
+- Deprecate `Wallet.saveSeed()` method in favor of `Wallet.save_seed_to_file`
 
 ### [0.12.1] - 2024-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add ability to import external wallets into CDP via a BIP-39 mnemonic phrase, as a 1-of-1 wallet
 - Add ability to import WalletData files exported by the NodeJS CDP SDK
 - Deprecate `Wallet.load_seed` method in favor of `Wallet.load_seed_from_file`
-- Deprecate `Wallet.saveSeed()` method in favor of `Wallet.save_seed_to_file`
+- Deprecate `Wallet.save_seed` method in favor of `Wallet.save_seed_to_file`
 
 ### [0.12.1] - 2024-12-10
 

--- a/cdp/__init__.py
+++ b/cdp/__init__.py
@@ -16,6 +16,7 @@ from cdp.transfer import Transfer
 from cdp.wallet import Wallet
 from cdp.wallet_address import WalletAddress
 from cdp.wallet_data import WalletData
+from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 from cdp.webhook import Webhook
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     "Wallet",
     "WalletAddress",
     "WalletData",
+    "MnemonicSeedPhrase",
     "Webhook",
     "Asset",
     "Transfer",

--- a/cdp/__init__.py
+++ b/cdp/__init__.py
@@ -7,6 +7,7 @@ from cdp.cdp import Cdp
 from cdp.contract_invocation import ContractInvocation
 from cdp.faucet_transaction import FaucetTransaction
 from cdp.hash_utils import hash_message, hash_typed_data_message
+from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 from cdp.payload_signature import PayloadSignature
 from cdp.smart_contract import SmartContract
 from cdp.sponsored_send import SponsoredSend
@@ -16,29 +17,28 @@ from cdp.transfer import Transfer
 from cdp.wallet import Wallet
 from cdp.wallet_address import WalletAddress
 from cdp.wallet_data import WalletData
-from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 from cdp.webhook import Webhook
 
 __all__ = [
-    "__version__",
+    "Address",
+    "Asset",
+    "Balance",
+    "BalanceMap",
     "Cdp",
     "ContractInvocation",
+    "FaucetTransaction",
+    "MnemonicSeedPhrase",
+    "PayloadSignature",
+    "SmartContract",
+    "SponsoredSend",
+    "Trade",
+    "Transaction",
+    "Transfer",
     "Wallet",
     "WalletAddress",
     "WalletData",
-    "MnemonicSeedPhrase",
     "Webhook",
-    "Asset",
-    "Transfer",
-    "Address",
-    "Transaction",
-    "Balance",
-    "BalanceMap",
-    "FaucetTransaction",
-    "Trade",
-    "SponsoredSend",
-    "PayloadSignature",
-    "SmartContract",
+    "__version__",
     "hash_message",
     "hash_typed_data_message",
 ]

--- a/cdp/cdp_api_client.py
+++ b/cdp/cdp_api_client.py
@@ -11,7 +11,7 @@ from cdp import __version__
 from cdp.client import rest
 from cdp.client.api_client import ApiClient
 from cdp.client.api_response import ApiResponse
-from cdp.client.api_response import T as ApiResponseT  # noqa: N811
+from cdp.client.api_response import T as ApiResponseT
 from cdp.client.configuration import Configuration
 from cdp.client.exceptions import ApiException
 from cdp.constants import SDK_DEFAULT_SOURCE

--- a/cdp/cdp_api_client.py
+++ b/cdp/cdp_api_client.py
@@ -11,7 +11,7 @@ from cdp import __version__
 from cdp.client import rest
 from cdp.client.api_client import ApiClient
 from cdp.client.api_response import ApiResponse
-from cdp.client.api_response import T as ApiResponseT
+from cdp.client.api_response import T as ApiResponseT  # noqa: N811
 from cdp.client.configuration import Configuration
 from cdp.client.exceptions import ApiException
 from cdp.constants import SDK_DEFAULT_SOURCE

--- a/cdp/mnemonic_seed_phrase.py
+++ b/cdp/mnemonic_seed_phrase.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+@dataclass
+class MnemonicSeedPhrase:
+    """Class representing a BIP-39mnemonic seed phrase.
+    
+    Used to import external wallets into CDP as 1-of-1 wallets.
+
+    Args:
+        mnemonic_phrase (str): A valid BIP-39 mnemonic phrase (12, 15, 18, 21, or 24 words).
+    """
+    mnemonic_phrase: str 

--- a/cdp/mnemonic_seed_phrase.py
+++ b/cdp/mnemonic_seed_phrase.py
@@ -1,12 +1,15 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class MnemonicSeedPhrase:
     """Class representing a BIP-39mnemonic seed phrase.
-    
+
     Used to import external wallets into CDP as 1-of-1 wallets.
 
     Args:
         mnemonic_phrase (str): A valid BIP-39 mnemonic phrase (12, 15, 18, 21, or 24 words).
+
     """
-    mnemonic_phrase: str 
+
+    mnemonic_phrase: str

--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -259,7 +259,7 @@ class Wallet:
             page = response.next_page
 
     @classmethod
-    def import_data(cls, data: WalletData | MnemonicSeedPhrase) -> "Wallet":
+    def import_wallet(cls, data: WalletData | MnemonicSeedPhrase) -> "Wallet":
         """Import a wallet from previously exported wallet data or a mnemonic seed phrase.
 
         Args:
@@ -301,6 +301,23 @@ class Wallet:
             return wallet
 
         raise ValueError("Data must be a WalletData or MnemonicSeedPhrase instance")
+
+    @classmethod
+    def import_data(cls, data: WalletData) -> "Wallet":
+        """Import a wallet from previously exported wallet data.
+
+        Args:
+            data (WalletData): The wallet data to import.
+
+        Returns:
+            Wallet: The imported wallet.
+
+        Raises:
+            ValueError: If data is not a WalletData instance.
+            Exception: If there's an error getting the wallet.
+
+        """
+        return cls.import_wallet(data)
 
     def create_address(self) -> "WalletAddress":
         """Create a new address for the wallet.

--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -31,12 +31,12 @@ from cdp.contract_invocation import ContractInvocation
 from cdp.faucet_transaction import FaucetTransaction
 from cdp.fund_operation import FundOperation
 from cdp.fund_quote import FundQuote
+from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 from cdp.payload_signature import PayloadSignature
 from cdp.smart_contract import SmartContract
 from cdp.trade import Trade
 from cdp.wallet_address import WalletAddress
 from cdp.wallet_data import WalletData
-from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 from cdp.webhook import Webhook
 
 
@@ -131,6 +131,7 @@ class Wallet:
 
         Raises:
             Exception: If there's an error creating the wallet.
+
         """
         return cls.create_with_seed(
             seed=None,
@@ -160,6 +161,7 @@ class Wallet:
 
         Raises:
             Exception: If there's an error creating the wallet.
+
         """
         create_wallet_request = CreateWalletRequest(
             wallet=CreateWalletRequestWallet(
@@ -257,7 +259,7 @@ class Wallet:
             page = response.next_page
 
     @classmethod
-    def import_data(cls, data: Union[WalletData, MnemonicSeedPhrase]) -> "Wallet":
+    def import_data(cls, data: WalletData | MnemonicSeedPhrase) -> "Wallet":
         """Import a wallet from previously exported wallet data or a mnemonic seed phrase.
 
         Args:
@@ -272,6 +274,7 @@ class Wallet:
             ValueError: If data is not a WalletData or MnemonicSeedPhrase instance.
             ValueError: If the mnemonic phrase is invalid.
             Exception: If there's an error getting the wallet.
+
         """
         if isinstance(data, MnemonicSeedPhrase):
             # Validate mnemonic phrase
@@ -550,8 +553,10 @@ class Wallet:
 
         Raises:
             ValueError: If the wallet does not have a seed loaded.
+
         """
         import warnings
+
         warnings.warn(
             "save_seed() is deprecated and will be removed in a future version. Use save_seed_to_file() instead.",
             DeprecationWarning,
@@ -609,8 +614,10 @@ class Wallet:
 
         Raises:
             ValueError: If the file does not contain seed data for this wallet or if decryption fails.
+
         """
         import warnings
+
         warnings.warn(
             "load_seed() is deprecated and will be removed in a future version. Use load_seed_from_file() instead.",
             DeprecationWarning,

--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -122,9 +122,9 @@ class Wallet:
         """Create a new wallet with a random seed.
 
         Args:
-            network_id (str) - The network ID of the wallet. Defaults to "base-sepolia".
-            interval_seconds (float) - The interval between checks in seconds. Defaults to 0.2.
-            timeout_seconds (float) - The maximum time to wait for the server signer to be active. Defaults to 20.
+            network_id (str): The network ID of the wallet. Defaults to "base-sepolia".
+            interval_seconds (float): The interval between checks in seconds. Defaults to 0.2.
+            timeout_seconds (float): The maximum time to wait for the server signer to be active. Defaults to 20.
 
         Returns:
             Wallet: The created wallet object.
@@ -151,10 +151,10 @@ class Wallet:
         """Create a new wallet with the given seed.
 
         Args:
-            seed (str) - The seed to use for the wallet. If None, a random seed will be generated.
-            network_id (str) - The network ID of the wallet. Defaults to "base-sepolia".
-            interval_seconds (float) - The interval between checks in seconds. Defaults to 0.2.
-            timeout_seconds (float) - The maximum time to wait for the server signer to be active. Defaults to 20.
+            seed (str): The seed to use for the wallet. If None, a random seed will be generated.
+            network_id (str): The network ID of the wallet. Defaults to "base-sepolia".
+            interval_seconds (float): The interval between checks in seconds. Defaults to 0.2.
+            timeout_seconds (float): The maximum time to wait for the server signer to be active. Defaults to 20.
 
         Returns:
             Wallet: The created wallet object.
@@ -545,7 +545,9 @@ class Wallet:
         return WalletData(self.id, self._seed, self.network_id)
 
     def save_seed(self, file_path: str, encrypt: bool | None = False) -> None:
-        """[Deprecated] Use save_seed_to_file() instead. This method will be removed in a future version.
+        """[Save the wallet seed to a file (deprecated).
+
+        This method is deprecated, and will be removed in a future version. Use load_seed_from_file() instead.
 
         Args:
             file_path (str): The path to the file where the seed will be saved.
@@ -607,7 +609,9 @@ class Wallet:
             json.dump(existing_seeds, f, indent=4)
 
     def load_seed(self, file_path: str) -> None:
-        """[Deprecated] Use load_seed_from_file() instead. This method will be removed in a future version.
+        """Load the wallet seed from a file (deprecated).
+
+        This method is deprecated, and will be removed in a future version. Use load_seed_from_file() instead.
 
         Args:
             file_path (str): The path to the file containing the seed data.
@@ -617,7 +621,6 @@ class Wallet:
 
         """
         import warnings
-
         warnings.warn(
             "load_seed() is deprecated and will be removed in a future version. Use load_seed_from_file() instead.",
             DeprecationWarning,

--- a/cdp/wallet_data.py
+++ b/cdp/wallet_data.py
@@ -98,9 +98,10 @@ class WalletData:
             WalletData: The wallet data.
 
         Raises:
-            ValueError: 
+            ValueError:
             - If both 'wallet_id' and 'walletId' are present, or if neither is present.
             - If both 'network_id' and 'networkId' are present, or if neither is present.
+
         """
         has_snake_case_wallet = "wallet_id" in data
         has_camel_case_wallet = "walletId" in data
@@ -124,11 +125,7 @@ class WalletData:
 
         network_id = data.get("network_id") if has_snake_case_network else data.get("networkId")
 
-        return cls(
-            wallet_id,
-            seed,
-            network_id
-        )
+        return cls(wallet_id, seed, network_id)
 
     def __str__(self) -> str:
         """Return a string representation of the WalletData object.

--- a/cdp/wallet_data.py
+++ b/cdp/wallet_data.py
@@ -25,6 +25,16 @@ class WalletData:
         return self._wallet_id
 
     @property
+    def walletId(self) -> str | None:
+        """Get the ID of the wallet (camelCase alias).
+
+        Returns:
+            str | None: The ID of the wallet.
+
+        """
+        return self._wallet_id
+
+    @property
     def seed(self) -> str:
         """Get the seed of the wallet.
 
@@ -39,22 +49,41 @@ class WalletData:
         """Get the network ID of the wallet.
 
         Returns:
-            str: The network ID of the wallet.
+            str | None: The network ID of the wallet.
 
         """
         return self._network_id
 
-    def to_dict(self) -> dict[str, str]:
+    @property
+    def networkId(self) -> str | None:
+        """Get the network ID of the wallet (camelCase alias).
+
+        Returns:
+            str | None: The network ID of the wallet.
+
+        """
+        return self._network_id
+
+    def to_dict(self, camel_case: bool = False) -> dict[str, str]:
         """Convert the wallet data to a dictionary.
+
+        Args:
+            camel_case (bool): Whether to use camelCase keys. Defaults to False.
 
         Returns:
             dict[str, str]: The dictionary representation of the wallet data.
 
         """
-        result = {"wallet_id": self.wallet_id, "seed": self.seed}
-        if self._network_id is not None:
-            result["network_id"] = self.network_id
-        return result
+        if camel_case:
+            result = {"walletId": self.walletId, "seed": self.seed}
+            if self._network_id is not None:
+                result["networkId"] = self.networkId
+            return result
+        else:
+            result = {"wallet_id": self.wallet_id, "seed": self.seed}
+            if self._network_id is not None:
+                result["network_id"] = self.network_id
+            return result
 
     @classmethod
     def from_dict(cls, data: dict[str, str]) -> "WalletData":
@@ -62,15 +91,43 @@ class WalletData:
 
         Args:
             data (dict[str, str]): The data to create the WalletData object from.
+                Must contain exactly one of ('wallet_id' or 'walletId'), and a seed.
+                May optionally contain exactly one of ('network_id' or 'networkId').
 
         Returns:
             WalletData: The wallet data.
 
+        Raises:
+            ValueError: 
+            - If both 'wallet_id' and 'walletId' are present, or if neither is present.
+            - If both 'network_id' and 'networkId' are present, or if neither is present.
         """
+        has_snake_case_wallet = "wallet_id" in data
+        has_camel_case_wallet = "walletId" in data
+
+        if has_snake_case_wallet and has_camel_case_wallet:
+            raise ValueError("Data cannot contain both 'wallet_id' and 'walletId' keys")
+
+        wallet_id = data.get("wallet_id") if has_snake_case_wallet else data.get("walletId")
+        if wallet_id is None:
+            raise ValueError("Data must contain either 'wallet_id' or 'walletId'")
+
+        seed = data.get("seed")
+        if seed is None:
+            raise ValueError("Data must contain 'seed'")
+
+        has_snake_case_network = "network_id" in data
+        has_camel_case_network = "networkId" in data
+
+        if has_snake_case_network and has_camel_case_network:
+            raise ValueError("Data cannot contain both 'network_id' and 'networkId' keys")
+
+        network_id = data.get("network_id") if has_snake_case_network else data.get("networkId")
+
         return cls(
-            data["wallet_id"],
-            data["seed"],
-            data.get("network_id")
+            wallet_id,
+            seed,
+            network_id
         )
 
     def __str__(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ exclude = ["./build/**", "./dist/**", "./docs/**", "./cdp/client/**"]
 select = ["E", "F", "I", "N", "W", "D", "UP", "B", "C4", "SIM", "RUF"]
 ignore = ["D213", "D203", "D100", "D104", "D107", "E501"]
 
+[tool.ruff.lint.pep8-naming]
+# Allow camelCase property names in WalletData import for cross-compatibility with Node.JS SDK
+classmethod-decorators = ["classmethod"]
+ignore-names = ["networkId", "walletId"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -731,7 +731,7 @@ def test_wallet_import_from_mnemonic_seed_phrase(
     # Import wallet using mnemonic
     from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 
-    wallet = Wallet.import_data(MnemonicSeedPhrase(valid_mnemonic))
+    wallet = Wallet.import_wallet(MnemonicSeedPhrase(valid_mnemonic))
 
     # Verify the wallet was created successfully
     assert isinstance(wallet, Wallet)
@@ -747,7 +747,7 @@ def test_wallet_import_from_mnemonic_empty_phrase():
     from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 
     with pytest.raises(ValueError, match="BIP-39 mnemonic seed phrase must be provided"):
-        Wallet.import_data(MnemonicSeedPhrase(""))
+        Wallet.import_wallet(MnemonicSeedPhrase(""))
 
 
 def test_wallet_import_from_mnemonic_invalid_phrase():
@@ -755,4 +755,4 @@ def test_wallet_import_from_mnemonic_invalid_phrase():
     from cdp.mnemonic_seed_phrase import MnemonicSeedPhrase
 
     with pytest.raises(ValueError, match="Invalid BIP-39 mnemonic seed phrase"):
-        Wallet.import_data(MnemonicSeedPhrase("invalid mnemonic phrase"))
+        Wallet.import_wallet(MnemonicSeedPhrase("invalid mnemonic phrase"))


### PR DESCRIPTION
### What changed? Why?

- Support external 1-of-1 wallet import via BIP-39 mnemonic phrases (12, 15, 18, 21, or 24 words)
- Support import of wallet data exported from CDP Python SDK
- Deprecate `Wallet.load_seed` method in favor of `Wallet.load_seed_from_file`
- Deprecate `Wallet.save_seed` method in favor of `Wallet.save_seed_to_file`

### Testing

Tested via:
- Import of 12, 15, 18, 21, and 24-word mnemonic seed phrases
- Export of wallets generated via mnemonic seed phrases
- Import of wallets generated via mnemonic seed phrases, that were then exported
- Successfully imported wallet exported from CDP NodeJS SDK `v0.11.0`
