### PR TITLE
chore: update transfer wait timeout to 40 seconds

### DIFF
--- a/cdp/transfer.py
+++ b/cdp/transfer.py
@@ -273,7 +273,7 @@ class Transfer:
 
         return self
 
-    def wait(self, interval_seconds: float = 0.2, timeout_seconds: float = 20) -> "Transfer":
+    def wait(self, interval_seconds: float = 0.2, timeout_seconds: float = 40) -> "Transfer":
         """Wait for the transfer to complete.
 
         Args:


### PR DESCRIPTION
### What changed? Why?

We're seeing occasional timeouts, so we are increasing the default while we explore solutions.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
