### PR TITLE
make delete a instance method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.14.0] - 2025-01-16
 
 ### Added
-- Add `Webhook.delete_webhook` method to delete a webhook instance.
+- Add `Webhook.delete` instance method to delete a webhook instance.
 
 ### Deprecated
 - Deprecate `Webhook.delete` static method in `Webhook` which deletes a webhook by its ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CDP Python SDK Changelog
 
+## [0.14.0] - 2025-01-16
+
+### Added
+- Add `Webhook.delete_webhook` method to delete a webhook instance.
+
+### Deprecated
+- Deprecate `Webhook.delete` static method in `Webhook` which deletes a webhook by its ID.
+
 ## [0.13.0] - 2024-12-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.14.0] - 2025-01-16
 
 ### Added
-- Add `Webhook.delete` instance method to delete a webhook instance.
+- Add `Webhook.delete_webhook` instance method to delete a webhook instance.
 
 ### Deprecated
 - Deprecate `Webhook.delete` static method in `Webhook` which deletes a webhook by its ID.

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+import warnings
 
 from cdp.cdp import Cdp
 from cdp.client.models.create_webhook_request import CreateWebhookRequest
@@ -6,7 +7,6 @@ from cdp.client.models.update_webhook_request import UpdateWebhookRequest
 from cdp.client.models.webhook import Webhook as WebhookModel
 from cdp.client.models.webhook import WebhookEventFilter, WebhookEventType, WebhookEventTypeFilter
 from cdp.client.models.webhook_list import WebhookList
-import warnings
 
 
 class Webhook:
@@ -142,21 +142,20 @@ class Webhook:
         """Delete a webhook by its ID.
 
         Args:
-
             webhook_id (str): The ID of the webhook to delete.
 
         Deprecated:
             This static method is deprecated. Please use the instance method instead:
-            webhook_instance.delete()
+            webhook_instance.delete_webhook()
         """
         warnings.warn(
-            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete()",
+            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete_webhook()",
             DeprecationWarning,
             stacklevel=2,
         )
         Cdp.api_clients.webhooks.delete_webhook(webhook_id)
 
-    def delete(self) -> None:
+    def delete_webhook(self) -> None:
         """Delete this webhook.
 
         This method deletes the current webhook instance from the system.

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -1,11 +1,10 @@
-from collections.abc import Iterator
-
 from cdp.cdp import Cdp
 from cdp.client.models.create_webhook_request import CreateWebhookRequest
 from cdp.client.models.update_webhook_request import UpdateWebhookRequest
 from cdp.client.models.webhook import Webhook as WebhookModel
 from cdp.client.models.webhook import WebhookEventFilter, WebhookEventType, WebhookEventTypeFilter
 from cdp.client.models.webhook_list import WebhookList
+from collections.abc import Iterator
 import warnings
 
 
@@ -142,15 +141,15 @@ class Webhook:
         """Delete a webhook by its ID.
 
         Args:
-
             webhook_id (str): The ID of the webhook to delete.
 
         Deprecated:
             This static method is deprecated. Please use the instance method instead:
-            webhook_instance.delete_webhook()
+            webhook_instance.delete()
+
         """
         warnings.warn(
-            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete_webhook()",
+            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete()",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator
-import warnings
 
 from cdp.cdp import Cdp
 from cdp.client.models.create_webhook_request import CreateWebhookRequest
@@ -7,6 +6,7 @@ from cdp.client.models.update_webhook_request import UpdateWebhookRequest
 from cdp.client.models.webhook import Webhook as WebhookModel
 from cdp.client.models.webhook import WebhookEventFilter, WebhookEventType, WebhookEventTypeFilter
 from cdp.client.models.webhook_list import WebhookList
+import warnings
 
 
 class Webhook:
@@ -142,20 +142,21 @@ class Webhook:
         """Delete a webhook by its ID.
 
         Args:
+
             webhook_id (str): The ID of the webhook to delete.
 
         Deprecated:
             This static method is deprecated. Please use the instance method instead:
-            webhook_instance.delete_webhook()
+            webhook_instance.delete()
         """
         warnings.warn(
-            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete_webhook()",
+            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete()",
             DeprecationWarning,
             stacklevel=2,
         )
         Cdp.api_clients.webhooks.delete_webhook(webhook_id)
 
-    def delete_webhook(self) -> None:
+    def delete(self) -> None:
         """Delete this webhook.
 
         This method deletes the current webhook instance from the system.

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -150,11 +150,11 @@ class Webhook:
 
         Deprecated:
             This static method is deprecated. Please use the instance method instead:
-            webhook_instance.delete()
+            webhook_instance.delete_webhook()
 
         """
         warnings.warn(
-            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete()",
+            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete_webhook()",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -1,11 +1,16 @@
+import warnings
+from collections.abc import Iterator
+
 from cdp.cdp import Cdp
 from cdp.client.models.create_webhook_request import CreateWebhookRequest
 from cdp.client.models.update_webhook_request import UpdateWebhookRequest
 from cdp.client.models.webhook import Webhook as WebhookModel
-from cdp.client.models.webhook import WebhookEventFilter, WebhookEventType, WebhookEventTypeFilter
+from cdp.client.models.webhook import (
+    WebhookEventFilter,
+    WebhookEventType,
+    WebhookEventTypeFilter,
+)
 from cdp.client.models.webhook_list import WebhookList
-from collections.abc import Iterator
-import warnings
 
 
 class Webhook:

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+import warnings
 
 from cdp.cdp import Cdp
 from cdp.client.models.create_webhook_request import CreateWebhookRequest
@@ -143,8 +144,23 @@ class Webhook:
         Args:
             webhook_id (str): The ID of the webhook to delete.
 
+        Deprecated:
+            This static method is deprecated. Please use the instance method instead:
+            webhook_instance.delete_webhook()
         """
+        warnings.warn(
+            "This static method is deprecated. Please use the instance method instead: webhook_instance.delete_webhook()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         Cdp.api_clients.webhooks.delete_webhook(webhook_id)
+
+    def delete_webhook(self) -> None:
+        """Delete this webhook.
+
+        This method deletes the current webhook instance from the system.
+        """
+        Cdp.api_clients.webhooks.delete_webhook(self.id)
 
     def update(
         self,

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -136,12 +136,15 @@ class Webhook:
 
             page = response.next_page
 
-    def delete(self) -> None:
-        """Delete this webhook.
+    @staticmethod
+    def delete(webhook_id: str) -> None:
+        """Delete a webhook by its ID.
 
-        This method deletes the current webhook instance from the system.
+        Args:
+            webhook_id (str): The ID of the webhook to delete.
+
         """
-        Cdp.api_clients.webhooks.delete_webhook(self.id)
+        Cdp.api_clients.webhooks.delete_webhook(webhook_id)
 
     def update(
         self,

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -136,15 +136,12 @@ class Webhook:
 
             page = response.next_page
 
-    @staticmethod
-    def delete(webhook_id: str) -> None:
-        """Delete a webhook by its ID.
+    def delete(self) -> None:
+        """Delete this webhook.
 
-        Args:
-            webhook_id (str): The ID of the webhook to delete.
-
+        This method deletes the current webhook instance from the system.
         """
-        Cdp.api_clients.webhooks.delete_webhook(webhook_id)
+        Cdp.api_clients.webhooks.delete_webhook(self.id)
 
     def update(
         self,

--- a/cdp/webhook.py
+++ b/cdp/webhook.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator
-import warnings
 
 from cdp.cdp import Cdp
 from cdp.client.models.create_webhook_request import CreateWebhookRequest
@@ -7,6 +6,7 @@ from cdp.client.models.update_webhook_request import UpdateWebhookRequest
 from cdp.client.models.webhook import Webhook as WebhookModel
 from cdp.client.models.webhook import WebhookEventFilter, WebhookEventType, WebhookEventTypeFilter
 from cdp.client.models.webhook_list import WebhookList
+import warnings
 
 
 class Webhook:
@@ -142,6 +142,7 @@ class Webhook:
         """Delete a webhook by its ID.
 
         Args:
+
             webhook_id (str): The ID of the webhook to delete.
 
         Deprecated:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -93,3 +93,16 @@ def test_webhook_update(mock_api_clients, webhook_factory):
     assert isinstance(updated_webhook, Webhook)
     assert updated_webhook.notification_uri == new_notification_uri
     assert updated_webhook.id == webhook.id
+
+
+@patch("cdp.Cdp.api_clients")
+def test_webhook_instance_delete(mock_api_clients, webhook_factory):
+    """Test Webhook instance delete method."""
+    # Create a webhook instance using the factory
+    webhook = Webhook(model=webhook_factory(webhook_id="webhook-123"))
+    
+    # Call delete on the webhook instance
+    webhook.delete_webhook()
+
+    # Verify the API client was called with the correct webhook ID
+    mock_api_clients.webhooks.delete_webhook.assert_called_once_with("webhook-123")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -100,9 +100,9 @@ def test_webhook_instance_delete(mock_api_clients, webhook_factory):
     """Test Webhook instance delete method."""
     # Create a webhook instance using the factory
     webhook = Webhook(model=webhook_factory(webhook_id="webhook-123"))
-
+    
     # Call delete on the webhook instance
-    webhook.delete()
+    webhook.delete_webhook()
 
     # Verify the API client was called with the correct webhook ID
     mock_api_clients.webhooks.delete_webhook.assert_called_once_with("webhook-123")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -46,7 +46,7 @@ def test_webhook_delete(mock_api_clients, webhook_factory):
     """Test Webhook delete method."""
     # Create a webhook instance using the factory
     webhook = webhook_factory(webhook_id="webhook-123")
-
+    
     # Call delete on the webhook instance
     webhook.delete()
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -42,16 +42,13 @@ def test_webhook_creation(mock_api_clients, webhook_factory):
 
 
 @patch("cdp.Cdp.api_clients")
-def test_webhook_delete(mock_api_clients, webhook_factory):
+def test_webhook_delete(mock_api_clients):
     """Test Webhook delete method."""
-    # Create a webhook instance using the factory
-    webhook = webhook_factory(webhook_id="webhook-123")
-    
-    # Call delete on the webhook instance
-    webhook.delete()
+    webhook_id = "webhook-123"
 
-    # Verify the API client was called with the correct webhook ID
-    mock_api_clients.webhooks.delete_webhook.assert_called_once_with("webhook-123")
+    Webhook.delete(webhook_id)
+
+    mock_api_clients.webhooks.delete_webhook.assert_called_once_with(webhook_id)
 
 
 @patch("cdp.Cdp.api_clients")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -42,13 +42,16 @@ def test_webhook_creation(mock_api_clients, webhook_factory):
 
 
 @patch("cdp.Cdp.api_clients")
-def test_webhook_delete(mock_api_clients):
+def test_webhook_delete(mock_api_clients, webhook_factory):
     """Test Webhook delete method."""
-    webhook_id = "webhook-123"
+    # Create a webhook instance using the factory
+    webhook = webhook_factory(webhook_id="webhook-123")
+    
+    # Call delete on the webhook instance
+    webhook.delete()
 
-    Webhook.delete(webhook_id)
-
-    mock_api_clients.webhooks.delete_webhook.assert_called_once_with(webhook_id)
+    # Verify the API client was called with the correct webhook ID
+    mock_api_clients.webhooks.delete_webhook.assert_called_once_with("webhook-123")
 
 
 @patch("cdp.Cdp.api_clients")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -100,7 +100,7 @@ def test_webhook_instance_delete(mock_api_clients, webhook_factory):
     """Test Webhook instance delete method."""
     # Create a webhook instance using the factory
     webhook = Webhook(model=webhook_factory(webhook_id="webhook-123"))
-    
+
     # Call delete on the webhook instance
     webhook.delete_webhook()
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -46,7 +46,7 @@ def test_webhook_delete(mock_api_clients, webhook_factory):
     """Test Webhook delete method."""
     # Create a webhook instance using the factory
     webhook = webhook_factory(webhook_id="webhook-123")
-    
+
     # Call delete on the webhook instance
     webhook.delete()
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -100,9 +100,9 @@ def test_webhook_instance_delete(mock_api_clients, webhook_factory):
     """Test Webhook instance delete method."""
     # Create a webhook instance using the factory
     webhook = Webhook(model=webhook_factory(webhook_id="webhook-123"))
-    
+
     # Call delete on the webhook instance
-    webhook.delete_webhook()
+    webhook.delete()
 
     # Verify the API client was called with the correct webhook ID
     mock_api_clients.webhooks.delete_webhook.assert_called_once_with("webhook-123")


### PR DESCRIPTION
### What changed? Why?

make python SDK's webhook deletion behave the same as node and ruby SDK, it will be a instance method without needing clients to enter a webhook ID. 

```
 wh1 = next(gen1)
CDP API REQUEST: GET https://api.cdp.coinbase.com/platform/v1/webhooks?limit=100
CDP API RESPONSE: Status: 200, Data: b'{"data":[{"created_at":"2024-12-13T20:24:39.256Z","event_type":"smart_contract_event_activity","event_type_filter":{"contract_addresses":["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"]},"id":"675c980709b4be439a116ade","network_id":"ethereum-mainnet","notification_uri":"https://webhook.site/57cb34a7-51aa-4ba8-b0a5-b435bebf99a5","updated_at":"2024-12-16T21:47:29.07Z"}],"has_more":false}\n'
>>> wh1.delete_webhook()
CDP API REQUEST: DELETE https://api.cdp.coinbase.com/platform/v1/webhooks/675c980709b4be439a116ade
CDP API RESPONSE: Status: 200, Data: b''

```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
