### PR TITLE
fix: skip faucet e2e tests if limit reached

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -73,7 +73,7 @@ def test_wallet_transfer(imported_wallet):
     try:
         imported_wallet.faucet().wait()
     except FaucetLimitReachedError:
-        pytest.skip("Faucet limit reached")
+       print("Faucet limit reached, continuing...")
 
     destination_wallet = Wallet.create()
     
@@ -102,8 +102,13 @@ def test_wallet_transfer(imported_wallet):
 @pytest.mark.e2e
 def test_transaction_history(imported_wallet):
     """Test transaction history retrieval."""
-    # create a transaction
+    try:
+        imported_wallet.faucet().wait()
+    except FaucetLimitReachedError:
+       print("Faucet limit reached, continuing...")
+
     destination_wallet = Wallet.create()
+
     transfer = imported_wallet.transfer(
         amount=Decimal("0.000000001"),
         asset_id="eth",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -110,12 +110,12 @@ def test_transaction_history(imported_wallet):
     destination_wallet = Wallet.create()
 
     transfer = imported_wallet.transfer(
-        amount=Decimal("0.000000001"),
+        amount=Decimal("0.0001"),
         asset_id="eth",
         destination=destination_wallet
     ).wait()
 
-    time.sleep(2)
+    time.sleep(10)
 
     transactions = imported_wallet.default_address.transactions()
     matching_tx = None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -76,7 +76,7 @@ def test_wallet_transfer(imported_wallet):
        print("Faucet limit reached, continuing...")
 
     destination_wallet = Wallet.create()
-    
+
     initial_source_balance = Decimal(str(imported_wallet.balances().get("eth", 0)))
     initial_dest_balance = Decimal(str(destination_wallet.balances().get("eth", 0)))
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -68,40 +68,6 @@ def test_wallet_import(wallet_data):
 
 
 @pytest.mark.e2e
-def test_wallet_faucet(imported_wallet):
-    """Test wallet faucet with ETH."""
-    initial_balances = imported_wallet.balances()
-    initial_eth_balance = Decimal(str(initial_balances.get("eth", 0)))
-
-    try:
-        imported_wallet.faucet()
-        time.sleep(5)  # increased wait time for balance to update
-
-        final_balances = imported_wallet.balances()
-        final_eth_balance = Decimal(str(final_balances.get("eth", 0)))
-        assert final_eth_balance > initial_eth_balance
-    except FaucetLimitReachedError:
-        pytest.skip("Faucet limit reached")
-
-
-@pytest.mark.e2e
-def test_wallet_faucet_usdc(imported_wallet):
-    """Test wallet faucet with USDC."""
-    initial_balances = imported_wallet.balances()
-    initial_usdc_balance = Decimal(str(initial_balances.get("usdc", 0)))
-
-    try:
-        imported_wallet.faucet(asset_id="usdc")
-        time.sleep(5)  # increased wait time for balance to update
-
-        final_balances = imported_wallet.balances()
-        final_usdc_balance = Decimal(str(final_balances.get("usdc", 0)))
-        assert final_usdc_balance > initial_usdc_balance
-    except FaucetLimitReachedError:
-        pytest.skip("Faucet limit reached")
-
-
-@pytest.mark.e2e
 def test_wallet_transfer(imported_wallet):
     """Test wallet transfer."""
     destination_wallet = Wallet.create()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,16 +1,15 @@
 import json
 import os
 import time
-
 from decimal import Decimal
-from dotenv import load_dotenv
+
 import pytest
+from dotenv import load_dotenv
 
 from cdp import Cdp
+from cdp.errors import FaucetLimitReachedError
 from cdp.wallet import Wallet
 from cdp.wallet_data import WalletData
-from cdp.errors import FaucetLimitReachedError
-
 
 load_dotenv()
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -70,8 +70,13 @@ def test_wallet_import(wallet_data):
 @pytest.mark.e2e
 def test_wallet_transfer(imported_wallet):
     """Test wallet transfer."""
-    destination_wallet = Wallet.create()
+    try:
+        imported_wallet.faucet().wait()
+    except FaucetLimitReachedError:
+        pytest.skip("Faucet limit reached")
 
+    destination_wallet = Wallet.create()
+    
     initial_source_balance = Decimal(str(imported_wallet.balances().get("eth", 0)))
     initial_dest_balance = Decimal(str(destination_wallet.balances().get("eth", 0)))
 
@@ -82,6 +87,7 @@ def test_wallet_transfer(imported_wallet):
     )
 
     transfer.wait()
+    time.sleep(2)
 
     assert transfer is not None
     assert transfer.status.value == "complete"
@@ -104,7 +110,7 @@ def test_transaction_history(imported_wallet):
         destination=destination_wallet
     ).wait()
 
-    time.sleep(10)
+    time.sleep(2)
 
     transactions = imported_wallet.default_address.transactions()
     matching_tx = None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,14 +1,16 @@
 import json
 import os
 import time
-from decimal import Decimal
 
-import pytest
+from decimal import Decimal
 from dotenv import load_dotenv
+import pytest
 
 from cdp import Cdp
 from cdp.wallet import Wallet
 from cdp.wallet_data import WalletData
+from cdp.errors import FaucetLimitReachedError
+
 
 load_dotenv()
 
@@ -72,12 +74,15 @@ def test_wallet_faucet(imported_wallet):
     initial_balances = imported_wallet.balances()
     initial_eth_balance = Decimal(str(initial_balances.get("eth", 0)))
 
-    imported_wallet.faucet().wait()
-    time.sleep(1)
+    try:
+        imported_wallet.faucet()
+        time.sleep(5)  # increased wait time for balance to update
 
-    final_balances = imported_wallet.balances()
-    final_eth_balance = Decimal(str(final_balances.get("eth", 0)))
-    assert final_eth_balance > initial_eth_balance
+        final_balances = imported_wallet.balances()
+        final_eth_balance = Decimal(str(final_balances.get("eth", 0)))
+        assert final_eth_balance > initial_eth_balance
+    except FaucetLimitReachedError:
+        pytest.skip("Faucet limit reached")
 
 
 @pytest.mark.e2e
@@ -86,12 +91,15 @@ def test_wallet_faucet_usdc(imported_wallet):
     initial_balances = imported_wallet.balances()
     initial_usdc_balance = Decimal(str(initial_balances.get("usdc", 0)))
 
-    imported_wallet.faucet(asset_id="usdc").wait()
-    time.sleep(1)
+    try:
+        imported_wallet.faucet(asset_id="usdc")
+        time.sleep(5)  # increased wait time for balance to update
 
-    final_balances = imported_wallet.balances()
-    final_usdc_balance = Decimal(str(final_balances.get("usdc", 0)))
-    assert final_usdc_balance > initial_usdc_balance
+        final_balances = imported_wallet.balances()
+        final_usdc_balance = Decimal(str(final_balances.get("usdc", 0)))
+        assert final_usdc_balance > initial_usdc_balance
+    except FaucetLimitReachedError:
+        pytest.skip("Faucet limit reached")
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### What changed? Why?
* removed faucet tests
* wrapping faucet calls in try/catch

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
