### PR TITLE
feat: Add support for deploying arbitrary contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- Add support for deploying custom contracts
+- Add `deploy_contract` method to `WalletAddress` and `Wallet` to deploy an arbitrary contract.
 
 ## [0.14.0] - 2025-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CDP Python SDK Changelog
 
+### Unreleased
+
+- Add support for deploying custom contracts
+
 ## [0.14.0] - 2025-01-14
 
 ### Added

--- a/cdp/client/__init__.py
+++ b/cdp/client/__init__.py
@@ -65,6 +65,8 @@ from cdp.client.models.broadcast_staking_operation_request import BroadcastStaki
 from cdp.client.models.broadcast_trade_request import BroadcastTradeRequest
 from cdp.client.models.broadcast_transfer_request import BroadcastTransferRequest
 from cdp.client.models.build_staking_operation_request import BuildStakingOperationRequest
+from cdp.client.models.compile_smart_contract_request import CompileSmartContractRequest
+from cdp.client.models.compiled_smart_contract import CompiledSmartContract
 from cdp.client.models.contract_event import ContractEvent
 from cdp.client.models.contract_event_list import ContractEventList
 from cdp.client.models.contract_invocation import ContractInvocation

--- a/cdp/client/api/smart_contracts_api.py
+++ b/cdp/client/api/smart_contracts_api.py
@@ -19,6 +19,8 @@ from typing_extensions import Annotated
 from pydantic import Field, StrictStr
 from typing import Optional
 from typing_extensions import Annotated
+from cdp.client.models.compile_smart_contract_request import CompileSmartContractRequest
+from cdp.client.models.compiled_smart_contract import CompiledSmartContract
 from cdp.client.models.create_smart_contract_request import CreateSmartContractRequest
 from cdp.client.models.deploy_smart_contract_request import DeploySmartContractRequest
 from cdp.client.models.read_contract_request import ReadContractRequest
@@ -44,6 +46,280 @@ class SmartContractsApi:
         if api_client is None:
             api_client = ApiClient.get_default()
         self.api_client = api_client
+
+
+    @validate_call
+    def compile_smart_contract(
+        self,
+        compile_smart_contract_request: CompileSmartContractRequest,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> CompiledSmartContract:
+        """Compile a smart contract
+
+        Compile a smart contract
+
+        :param compile_smart_contract_request: (required)
+        :type compile_smart_contract_request: CompileSmartContractRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._compile_smart_contract_serialize(
+            compile_smart_contract_request=compile_smart_contract_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "CompiledSmartContract",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def compile_smart_contract_with_http_info(
+        self,
+        compile_smart_contract_request: CompileSmartContractRequest,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[CompiledSmartContract]:
+        """Compile a smart contract
+
+        Compile a smart contract
+
+        :param compile_smart_contract_request: (required)
+        :type compile_smart_contract_request: CompileSmartContractRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._compile_smart_contract_serialize(
+            compile_smart_contract_request=compile_smart_contract_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "CompiledSmartContract",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def compile_smart_contract_without_preload_content(
+        self,
+        compile_smart_contract_request: CompileSmartContractRequest,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Compile a smart contract
+
+        Compile a smart contract
+
+        :param compile_smart_contract_request: (required)
+        :type compile_smart_contract_request: CompileSmartContractRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._compile_smart_contract_serialize(
+            compile_smart_contract_request=compile_smart_contract_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "CompiledSmartContract",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _compile_smart_contract_serialize(
+        self,
+        compile_smart_contract_request,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if compile_smart_contract_request is not None:
+            _body_params = compile_smart_contract_request
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params['Content-Type'] = _content_type
+        else:
+            _default_content_type = (
+                self.api_client.select_header_content_type(
+                    [
+                        'application/json'
+                    ]
+                )
+            )
+            if _default_content_type is not None:
+                _header_params['Content-Type'] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'apiKey'
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/v1/smart_contracts/compile',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
 
 
     @validate_call

--- a/cdp/client/models/__init__.py
+++ b/cdp/client/models/__init__.py
@@ -29,6 +29,8 @@ from cdp.client.models.broadcast_staking_operation_request import BroadcastStaki
 from cdp.client.models.broadcast_trade_request import BroadcastTradeRequest
 from cdp.client.models.broadcast_transfer_request import BroadcastTransferRequest
 from cdp.client.models.build_staking_operation_request import BuildStakingOperationRequest
+from cdp.client.models.compile_smart_contract_request import CompileSmartContractRequest
+from cdp.client.models.compiled_smart_contract import CompiledSmartContract
 from cdp.client.models.contract_event import ContractEvent
 from cdp.client.models.contract_event_list import ContractEventList
 from cdp.client.models.contract_invocation import ContractInvocation

--- a/cdp/client/models/compile_smart_contract_request.py
+++ b/cdp/client/models/compile_smart_contract_request.py
@@ -18,20 +18,18 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
-from cdp.client.models.smart_contract_options import SmartContractOptions
-from cdp.client.models.smart_contract_type import SmartContractType
+from typing import Any, ClassVar, Dict, List
 from typing import Optional, Set
 from typing_extensions import Self
 
-class CreateSmartContractRequest(BaseModel):
+class CompileSmartContractRequest(BaseModel):
     """
-    CreateSmartContractRequest
+    CompileSmartContractRequest
     """ # noqa: E501
-    type: SmartContractType
-    options: SmartContractOptions
-    compiled_smart_contract_id: Optional[StrictStr] = Field(default=None, description="The optional UUID of the compiled smart contract to deploy. This field is only required when SmartContractType is set to custom.")
-    __properties: ClassVar[List[str]] = ["type", "options", "compiled_smart_contract_id"]
+    solidity_input_json: StrictStr = Field(description="The JSON input containing the Solidity code, dependencies, and compiler settings.")
+    contract_name: StrictStr = Field(description="The name of the contract to compile.")
+    solidity_compiler_version: StrictStr = Field(description="The version of the Solidity compiler to use.")
+    __properties: ClassVar[List[str]] = ["solidity_input_json", "contract_name", "solidity_compiler_version"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -51,7 +49,7 @@ class CreateSmartContractRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CreateSmartContractRequest from a JSON string"""
+        """Create an instance of CompileSmartContractRequest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -72,14 +70,11 @@ class CreateSmartContractRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of options
-        if self.options:
-            _dict['options'] = self.options.to_dict()
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CreateSmartContractRequest from a dict"""
+        """Create an instance of CompileSmartContractRequest from a dict"""
         if obj is None:
             return None
 
@@ -87,9 +82,9 @@ class CreateSmartContractRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "type": obj.get("type"),
-            "options": SmartContractOptions.from_dict(obj["options"]) if obj.get("options") is not None else None,
-            "compiled_smart_contract_id": obj.get("compiled_smart_contract_id")
+            "solidity_input_json": obj.get("solidity_input_json"),
+            "contract_name": obj.get("contract_name"),
+            "solidity_compiler_version": obj.get("solidity_compiler_version")
         })
         return _obj
 

--- a/cdp/client/models/compiled_smart_contract.py
+++ b/cdp/client/models/compiled_smart_contract.py
@@ -19,19 +19,19 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
-from cdp.client.models.smart_contract_options import SmartContractOptions
-from cdp.client.models.smart_contract_type import SmartContractType
 from typing import Optional, Set
 from typing_extensions import Self
 
-class CreateSmartContractRequest(BaseModel):
+class CompiledSmartContract(BaseModel):
     """
-    CreateSmartContractRequest
+    Represents a compiled smart contract that can be deployed onchain
     """ # noqa: E501
-    type: SmartContractType
-    options: SmartContractOptions
-    compiled_smart_contract_id: Optional[StrictStr] = Field(default=None, description="The optional UUID of the compiled smart contract to deploy. This field is only required when SmartContractType is set to custom.")
-    __properties: ClassVar[List[str]] = ["type", "options", "compiled_smart_contract_id"]
+    compiled_smart_contract_id: Optional[StrictStr] = Field(default=None, description="The unique identifier of the compiled smart contract.")
+    solidity_input_json: Optional[StrictStr] = Field(default=None, description="The JSON-encoded input for the Solidity compiler")
+    contract_creation_bytecode: Optional[StrictStr] = Field(default=None, description="The contract creation bytecode which will be used with constructor arguments to deploy the contract")
+    abi: Optional[StrictStr] = Field(default=None, description="The JSON-encoded ABI of the contract")
+    contract_name: Optional[StrictStr] = Field(default=None, description="The name of the smart contract to deploy")
+    __properties: ClassVar[List[str]] = ["compiled_smart_contract_id", "solidity_input_json", "contract_creation_bytecode", "abi", "contract_name"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -51,7 +51,7 @@ class CreateSmartContractRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CreateSmartContractRequest from a JSON string"""
+        """Create an instance of CompiledSmartContract from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -72,14 +72,11 @@ class CreateSmartContractRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of options
-        if self.options:
-            _dict['options'] = self.options.to_dict()
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CreateSmartContractRequest from a dict"""
+        """Create an instance of CompiledSmartContract from a dict"""
         if obj is None:
             return None
 
@@ -87,9 +84,11 @@ class CreateSmartContractRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "type": obj.get("type"),
-            "options": SmartContractOptions.from_dict(obj["options"]) if obj.get("options") is not None else None,
-            "compiled_smart_contract_id": obj.get("compiled_smart_contract_id")
+            "compiled_smart_contract_id": obj.get("compiled_smart_contract_id"),
+            "solidity_input_json": obj.get("solidity_input_json"),
+            "contract_creation_bytecode": obj.get("contract_creation_bytecode"),
+            "abi": obj.get("abi"),
+            "contract_name": obj.get("contract_name")
         })
         return _obj
 

--- a/cdp/client/models/network_identifier.py
+++ b/cdp/client/models/network_identifier.py
@@ -34,6 +34,8 @@ class NetworkIdentifier(str, Enum):
     SOLANA_MINUS_DEVNET = 'solana-devnet'
     SOLANA_MINUS_MAINNET = 'solana-mainnet'
     ARBITRUM_MINUS_MAINNET = 'arbitrum-mainnet'
+    ARBITRUM_MINUS_SEPOLIA = 'arbitrum-sepolia'
+    BITCOIN_MINUS_MAINNET = 'bitcoin-mainnet'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/cdp/client/models/smart_contract.py
+++ b/cdp/client/models/smart_contract.py
@@ -40,7 +40,8 @@ class SmartContract(BaseModel):
     abi: StrictStr = Field(description="The JSON-encoded ABI of the contract")
     transaction: Optional[Transaction] = None
     is_external: StrictBool = Field(description="Whether the smart contract was deployed externally. If true, the deployer_address and transaction will be omitted.")
-    __properties: ClassVar[List[str]] = ["smart_contract_id", "network_id", "wallet_id", "contract_address", "contract_name", "deployer_address", "type", "options", "abi", "transaction", "is_external"]
+    compiled_smart_contract_id: Optional[StrictStr] = Field(default=None, description="The ID of the compiled smart contract that was used to deploy this contract")
+    __properties: ClassVar[List[str]] = ["smart_contract_id", "network_id", "wallet_id", "contract_address", "contract_name", "deployer_address", "type", "options", "abi", "transaction", "is_external", "compiled_smart_contract_id"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -109,7 +110,8 @@ class SmartContract(BaseModel):
             "options": SmartContractOptions.from_dict(obj["options"]) if obj.get("options") is not None else None,
             "abi": obj.get("abi"),
             "transaction": Transaction.from_dict(obj["transaction"]) if obj.get("transaction") is not None else None,
-            "is_external": obj.get("is_external")
+            "is_external": obj.get("is_external"),
+            "compiled_smart_contract_id": obj.get("compiled_smart_contract_id")
         })
         return _obj
 

--- a/cdp/client/models/smart_contract_options.py
+++ b/cdp/client/models/smart_contract_options.py
@@ -24,7 +24,7 @@ from pydantic import StrictStr, Field
 from typing import Union, List, Set, Optional, Dict
 from typing_extensions import Literal, Self
 
-SMARTCONTRACTOPTIONS_ONE_OF_SCHEMAS = ["MultiTokenContractOptions", "NFTContractOptions", "TokenContractOptions"]
+SMARTCONTRACTOPTIONS_ONE_OF_SCHEMAS = ["MultiTokenContractOptions", "NFTContractOptions", "TokenContractOptions", "str"]
 
 class SmartContractOptions(BaseModel):
     """
@@ -36,8 +36,10 @@ class SmartContractOptions(BaseModel):
     oneof_schema_2_validator: Optional[NFTContractOptions] = None
     # data type: MultiTokenContractOptions
     oneof_schema_3_validator: Optional[MultiTokenContractOptions] = None
-    actual_instance: Optional[Union[MultiTokenContractOptions, NFTContractOptions, TokenContractOptions]] = None
-    one_of_schemas: Set[str] = { "MultiTokenContractOptions", "NFTContractOptions", "TokenContractOptions" }
+    # data type: str
+    oneof_schema_4_validator: Optional[StrictStr] = Field(default=None, description="The JSON-encoded arguments to pass to the constructor method for a custom contract. The keys should be the constructor parameter names and the values should be the argument values.")
+    actual_instance: Optional[Union[MultiTokenContractOptions, NFTContractOptions, TokenContractOptions, str]] = None
+    one_of_schemas: Set[str] = { "MultiTokenContractOptions", "NFTContractOptions", "TokenContractOptions", "str" }
 
     model_config = ConfigDict(
         validate_assignment=True,
@@ -75,12 +77,18 @@ class SmartContractOptions(BaseModel):
             error_messages.append(f"Error! Input type `{type(v)}` is not `MultiTokenContractOptions`")
         else:
             match += 1
+        # validate data type: str
+        try:
+            instance.oneof_schema_4_validator = v
+            match += 1
+        except (ValidationError, ValueError) as e:
+            error_messages.append(str(e))
         if match > 1:
             # more than 1 match
-            raise ValueError("Multiple matches found when setting `actual_instance` in SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions. Details: " + ", ".join(error_messages))
+            raise ValueError("Multiple matches found when setting `actual_instance` in SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions, str. Details: " + ", ".join(error_messages))
         elif match == 0:
             # no match
-            raise ValueError("No match found when setting `actual_instance` in SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions. Details: " + ", ".join(error_messages))
+            raise ValueError("No match found when setting `actual_instance` in SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions, str. Details: " + ", ".join(error_messages))
         else:
             return v
 
@@ -113,13 +121,22 @@ class SmartContractOptions(BaseModel):
             match += 1
         except (ValidationError, ValueError) as e:
             error_messages.append(str(e))
+        # deserialize data into str
+        try:
+            # validation
+            instance.oneof_schema_4_validator = json.loads(json_str)
+            # assign value to actual_instance
+            instance.actual_instance = instance.oneof_schema_4_validator
+            match += 1
+        except (ValidationError, ValueError) as e:
+            error_messages.append(str(e))
 
         if match > 1:
             # more than 1 match
-            raise ValueError("Multiple matches found when deserializing the JSON string into SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions. Details: " + ", ".join(error_messages))
+            raise ValueError("Multiple matches found when deserializing the JSON string into SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions, str. Details: " + ", ".join(error_messages))
         elif match == 0:
             # no match
-            raise ValueError("No match found when deserializing the JSON string into SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions. Details: " + ", ".join(error_messages))
+            raise ValueError("No match found when deserializing the JSON string into SmartContractOptions with oneOf schemas: MultiTokenContractOptions, NFTContractOptions, TokenContractOptions, str. Details: " + ", ".join(error_messages))
         else:
             return instance
 
@@ -133,7 +150,7 @@ class SmartContractOptions(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict[str, Any], MultiTokenContractOptions, NFTContractOptions, TokenContractOptions]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], MultiTokenContractOptions, NFTContractOptions, TokenContractOptions, str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/cdp/smart_contract.py
+++ b/cdp/smart_contract.py
@@ -182,7 +182,7 @@ class SmartContract:
     @property
     def options(
         self,
-    ) -> TokenContractOptions | NFTContractOptions | MultiTokenContractOptions | None:
+    ) -> TokenContractOptions | NFTContractOptions | MultiTokenContractOptions | str | None:
         """Get the options of the smart contract.
 
         Returns:
@@ -205,6 +205,8 @@ class SmartContract:
             return self.NFTContractOptions(**options_dict)
         elif self.type == self.Type.ERC1155:
             return self.MultiTokenContractOptions(**options_dict)
+        elif self.type == self.Type.CUSTOM:
+            return json.dumps(options_dict, separators=(",", ":"))
         else:
             raise ValueError(f"Unknown smart contract type: {self.type}")
 
@@ -333,7 +335,8 @@ class SmartContract:
         wallet_id: str,
         address_id: str,
         type: Type,
-        options: TokenContractOptions | NFTContractOptions | MultiTokenContractOptions,
+        options: TokenContractOptions | NFTContractOptions | MultiTokenContractOptions | str,
+        compiled_smart_contract_id: str | None = None,
     ) -> "SmartContract":
         """Create a new SmartContract object.
 
@@ -342,6 +345,7 @@ class SmartContract:
             address_id: The ID of the address that will deploy the smart contract.
             type: The type of the smart contract (ERC20, ERC721, or ERC1155).
             options: The options of the smart contract.
+            compiled_smart_contract_id: The ID of the compiled smart contract. This must be set for custom contracts.
 
         Returns:
             The created smart contract.
@@ -356,6 +360,8 @@ class SmartContract:
             openapi_options = NFTContractOptions(**options)
         elif isinstance(options, cls.MultiTokenContractOptions):
             openapi_options = MultiTokenContractOptions(**options)
+        elif isinstance(options, str):
+            openapi_options = options
         else:
             raise ValueError(f"Unsupported options type: {type(options)}")
 
@@ -364,6 +370,7 @@ class SmartContract:
         create_smart_contract_request = CreateSmartContractRequest(
             type=type.value,
             options=smart_contract_options,
+            compiled_smart_contract_id=compiled_smart_contract_id,
         )
 
         model = Cdp.api_clients.smart_contracts.create_smart_contract(

--- a/cdp/wallet.py
+++ b/cdp/wallet.py
@@ -641,6 +641,7 @@ class Wallet:
 
         """
         import warnings
+
         warnings.warn(
             "load_seed() is deprecated and will be removed in a future version. Use load_seed_from_file() instead.",
             DeprecationWarning,
@@ -916,6 +917,35 @@ class Wallet:
             raise ValueError("Default address does not exist")
 
         return self.default_address.deploy_multi_token(uri)
+
+    def deploy_contract(
+        self,
+        solidity_version: str,
+        solidity_input_json: str,
+        contract_name: str,
+        constructor_args: dict,
+    ) -> SmartContract:
+        """Deploy a custom contract.
+
+        Args:
+            solidity_version (str): The version of the solidity compiler, must be 0.8.+, such as "0.8.28+commit.7893614a". See https://binaries.soliditylang.org/bin/list.json
+            solidity_input_json (str): The input json for the solidity compiler. See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description for more details.
+            contract_name (str): The name of the contract class to be deployed.
+            constructor_args (dict): The arguments for the constructor.
+
+        Returns:
+            SmartContract: The deployed smart contract.
+
+        Raises:
+            ValueError: If the default address does not exist.
+
+        """
+        if self.default_address is None:
+            raise ValueError("Default address does not exist")
+
+        return self.default_address.deploy_contract(
+            solidity_version, solidity_input_json, contract_name, constructor_args
+        )
 
     def fund(self, amount: Number | Decimal | str, asset_id: str) -> FundOperation:
         """Fund the wallet from your account on the Coinbase Platform.

--- a/tests/factories/compiled_smart_contract_factory.py
+++ b/tests/factories/compiled_smart_contract_factory.py
@@ -1,0 +1,21 @@
+import pytest
+
+from cdp.client.models.compiled_smart_contract import (
+    CompiledSmartContract as CompiledSmartContractModel,
+)
+
+
+@pytest.fixture
+def compiled_smart_contract_model_factory():
+    """Create and return a factory for creating CompiledSmartContractModel fixtures."""
+
+    def _create_compiled_smart_contract_model():
+        return CompiledSmartContractModel(
+            compiled_smart_contract_id="test-compiled-smart-contract-id",
+            contract_name="TestContract",
+            abi='{"abi":"data"}',
+            solidity_version="0.8.28+commit.7893614a",
+            solidity_input_json='{"abi":"data"}',
+        )
+
+    return _create_compiled_smart_contract_model

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -43,7 +43,7 @@ def test_wallet_data(wallet_data):
         "wallet_id": wallet_data["wallet_id"],
         "network_id": wallet_data["network_id"],
         "seed": wallet_data["seed"],
-        "default_address_id": wallet_data["default_address_id"]
+        "default_address_id": wallet_data["default_address_id"],
     }
 
     for key, value in expected.items():
@@ -73,7 +73,7 @@ def test_wallet_transfer(imported_wallet):
     try:
         imported_wallet.faucet().wait()
     except FaucetLimitReachedError:
-       print("Faucet limit reached, continuing...")
+        print("Faucet limit reached, continuing...")
 
     destination_wallet = Wallet.create()
 
@@ -81,9 +81,7 @@ def test_wallet_transfer(imported_wallet):
     initial_dest_balance = Decimal(str(destination_wallet.balances().get("eth", 0)))
 
     transfer = imported_wallet.transfer(
-        amount=Decimal("0.000000001"),
-        asset_id="eth",
-        destination=destination_wallet
+        amount=Decimal("0.000000001"), asset_id="eth", destination=destination_wallet
     )
 
     transfer.wait()
@@ -105,14 +103,12 @@ def test_transaction_history(imported_wallet):
     try:
         imported_wallet.faucet().wait()
     except FaucetLimitReachedError:
-       print("Faucet limit reached, continuing...")
+        print("Faucet limit reached, continuing...")
 
     destination_wallet = Wallet.create()
 
     transfer = imported_wallet.transfer(
-        amount=Decimal("0.0001"),
-        asset_id="eth",
-        destination=destination_wallet
+        amount=Decimal("0.0001"), asset_id="eth", destination=destination_wallet
     ).wait()
 
     time.sleep(10)
@@ -148,7 +144,7 @@ def test_wallet_export(imported_wallet):
         "encrypted": False,
         "auth_tag": "",
         "iv": "",
-        "network_id": exported_wallet.network_id
+        "network_id": exported_wallet.network_id,
     }
 
     os.unlink("test_seed.json")

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -85,9 +85,12 @@ def test_create_transfer(mock_asset, mock_api_clients, transfer_factory, asset_f
     assert create_transfer_request.network_id == "base-sepolia"
     assert create_transfer_request.gasless == gasless
 
+
 @patch("cdp.Cdp.api_clients")
 @patch("cdp.transfer.Asset")
-def test_create_transfer_with_skip_batching(mock_asset, mock_api_clients, transfer_factory, asset_factory):
+def test_create_transfer_with_skip_batching(
+    mock_asset, mock_api_clients, transfer_factory, asset_factory
+):
     """Test the creation of a Transfer object."""
     mock_fetch = Mock()
     mock_fetch.return_value = asset_factory()
@@ -127,6 +130,7 @@ def test_create_transfer_with_skip_batching(mock_asset, mock_api_clients, transf
     assert create_transfer_request.gasless
     assert create_transfer_request.skip_batching
 
+
 def test_create_transfer_invalid_skip_batching():
     """Test the creation of a Transfer object with skip_batching and no gasless."""
     with pytest.raises(ValueError, match="skip_batching requires gasless to be True"):
@@ -140,6 +144,7 @@ def test_create_transfer_invalid_skip_batching():
             gasless=False,
             skip_batching=True,
         )
+
 
 @patch("cdp.Cdp.api_clients")
 def test_list_transfers(mock_api_clients, transfer_factory):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -461,6 +461,32 @@ def test_wallet_deploy_multi_token(wallet_factory):
 
 
 @patch("cdp.Cdp.use_server_signer", True)
+def test_wallet_deploy_contract(wallet_factory):
+    """Test the deploy_contract method of a Wallet."""
+    wallet = wallet_factory()
+    mock_default_address = Mock(spec=WalletAddress)
+    mock_smart_contract = Mock(spec=SmartContract)
+    mock_default_address.deploy_contract.return_value = mock_smart_contract
+
+    with patch.object(
+        Wallet, "default_address", new_callable=PropertyMock
+    ) as mock_default_address_prop:
+        mock_default_address_prop.return_value = mock_default_address
+
+        smart_contract = wallet.deploy_contract(
+            solidity_version="0.8.28+commit.7893614a",
+            solidity_input_json="{}",
+            contract_name="TestContract",
+            constructor_args={"arg1": "value1"},
+        )
+
+        assert isinstance(smart_contract, SmartContract)
+        mock_default_address.deploy_contract.assert_called_once_with(
+            "0.8.28+commit.7893614a", "{}", "TestContract", {"arg1": "value1"}
+        )
+
+
+@patch("cdp.Cdp.use_server_signer", True)
 def test_wallet_deploy_token_no_default_address(wallet_factory):
     """Test the deploy_token method of a Wallet with no default address."""
     wallet = wallet_factory()
@@ -500,6 +526,25 @@ def test_wallet_deploy_multi_token_no_default_address(wallet_factory):
 
         with pytest.raises(ValueError, match="Default address does not exist"):
             wallet.deploy_multi_token(uri="https://example.com/multi-token/{id}.json")
+
+
+@patch("cdp.Cdp.use_server_signer", True)
+def test_wallet_deploy_contract_no_default_address(wallet_factory):
+    """Test the deploy_contract method of a Wallet with no default address."""
+    wallet = wallet_factory()
+
+    with patch.object(
+        Wallet, "default_address", new_callable=PropertyMock
+    ) as mock_default_address_prop:
+        mock_default_address_prop.return_value = None
+
+        with pytest.raises(ValueError, match="Default address does not exist"):
+            wallet.deploy_contract(
+                solidity_version="0.8.28+commit.7893614a",
+                solidity_input_json="{}",
+                contract_name="TestContract",
+                constructor_args={"arg1": "value1"},
+            )
 
 
 @patch("cdp.Cdp.use_server_signer", True)
@@ -562,6 +607,32 @@ def test_wallet_deploy_multi_token_with_server_signer(wallet_factory):
         assert isinstance(smart_contract, SmartContract)
         mock_default_address.deploy_multi_token.assert_called_once_with(
             "https://example.com/multi-token/{id}.json"
+        )
+
+
+@patch("cdp.Cdp.use_server_signer", True)
+def test_wallet_deploy_contract_with_server_signer(wallet_factory):
+    """Test the deploy_contract method of a Wallet with server-signer."""
+    wallet = wallet_factory()
+    mock_default_address = Mock(spec=WalletAddress)
+    mock_smart_contract = Mock(spec=SmartContract)
+    mock_default_address.deploy_contract.return_value = mock_smart_contract
+
+    with patch.object(
+        Wallet, "default_address", new_callable=PropertyMock
+    ) as mock_default_address_prop:
+        mock_default_address_prop.return_value = mock_default_address
+
+        smart_contract = wallet.deploy_contract(
+            solidity_version="0.8.28+commit.7893614a",
+            solidity_input_json="{}",
+            contract_name="TestContract",
+            constructor_args={"arg1": "value1"},
+        )
+
+        assert isinstance(smart_contract, SmartContract)
+        mock_default_address.deploy_contract.assert_called_once_with(
+            "0.8.28+commit.7893614a", "{}", "TestContract", {"arg1": "value1"}
         )
 
 


### PR DESCRIPTION
### What changed? Why?
- Added `deploy_contract` in wallet_address.py and wallet.py to support deploying an arbitrary contract using the compiler version, solidity input json, contract name of the class to be deployed, and constructor arguments

### Testing
- Unit tests added
- E2E test succeeds

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
