### PR TITLE
feat: stabalize e2e test workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,18 +5,13 @@ on: [pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        python: ["3.10"]
-
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '3.10'
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -30,7 +25,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./.venv
-          key: venv-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python: ["3.10", "3.11", "3.12"]
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -82,12 +82,8 @@ def test_wallet_transfer(imported_wallet):
 
     transfer = imported_wallet.transfer(
         amount=Decimal("0.000000001"), asset_id="eth", destination=destination_wallet
-    )
+    ).wait()
 
-    transfer.wait()
-    time.sleep(2)
-
-    assert transfer is not None
     assert transfer.status.value == "complete"
 
     final_source_balance = Decimal(str(imported_wallet.balances().get("eth", 0)))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -75,7 +75,7 @@ def test_wallet_transfer(imported_wallet):
     initial_source_balance = imported_wallet.balance("eth")
     initial_dest_balance = destination_wallet.balance("eth")
 
-    if initial_source_balance < 0.000000001:
+    if initial_source_balance < 0.0001:
         try:
             imported_wallet.faucet().wait()
         except FaucetLimitReachedError:
@@ -100,7 +100,7 @@ def test_transaction_history(imported_wallet):
     destination_wallet = Wallet.create()
 
     initial_source_balance = imported_wallet.balance("eth")
-    if initial_source_balance < 0.000000001:
+    if initial_source_balance < 0.0001:
         try:
             imported_wallet.faucet().wait()
         except FaucetLimitReachedError:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -70,7 +70,6 @@ def test_wallet_import(wallet_data):
 @pytest.mark.e2e
 def test_wallet_transfer(imported_wallet):
     """Test wallet transfer."""
-
     destination_wallet = Wallet.create()
 
     initial_source_balance = imported_wallet.balance("eth")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -70,15 +70,17 @@ def test_wallet_import(wallet_data):
 @pytest.mark.e2e
 def test_wallet_transfer(imported_wallet):
     """Test wallet transfer."""
-    try:
-        imported_wallet.faucet().wait()
-    except FaucetLimitReachedError:
-        print("Faucet limit reached, continuing...")
 
     destination_wallet = Wallet.create()
 
-    initial_source_balance = Decimal(str(imported_wallet.balances().get("eth", 0)))
-    initial_dest_balance = Decimal(str(destination_wallet.balances().get("eth", 0)))
+    initial_source_balance = imported_wallet.balance("eth")
+    initial_dest_balance = destination_wallet.balance("eth")
+
+    if initial_source_balance < 0.000000001:
+        try:
+            imported_wallet.faucet().wait()
+        except FaucetLimitReachedError:
+            print("Faucet limit reached, continuing...")
 
     transfer = imported_wallet.transfer(
         amount=Decimal("0.000000001"), asset_id="eth", destination=destination_wallet
@@ -86,8 +88,8 @@ def test_wallet_transfer(imported_wallet):
 
     assert transfer.status.value == "complete"
 
-    final_source_balance = Decimal(str(imported_wallet.balances().get("eth", 0)))
-    final_dest_balance = Decimal(str(destination_wallet.balances().get("eth", 0)))
+    final_source_balance = imported_wallet.balance("eth")
+    final_dest_balance = destination_wallet.balance("eth")
 
     assert final_source_balance < initial_source_balance
     assert final_dest_balance > initial_dest_balance
@@ -96,15 +98,17 @@ def test_wallet_transfer(imported_wallet):
 @pytest.mark.e2e
 def test_transaction_history(imported_wallet):
     """Test transaction history retrieval."""
-    try:
-        imported_wallet.faucet().wait()
-    except FaucetLimitReachedError:
-        print("Faucet limit reached, continuing...")
-
     destination_wallet = Wallet.create()
 
+    initial_source_balance = imported_wallet.balance("eth")
+    if initial_source_balance < 0.000000001:
+        try:
+            imported_wallet.faucet().wait()
+        except FaucetLimitReachedError:
+            print("Faucet limit reached, continuing...")
+
     transfer = imported_wallet.transfer(
-        amount=Decimal("0.0001"), asset_id="eth", destination=destination_wallet
+        amount=Decimal("0.000000001"), asset_id="eth", destination=destination_wallet
     ).wait()
 
     time.sleep(10)


### PR DESCRIPTION
### What changed? Why?
* configuration changes for serial job execution
* pinning python 3.10
* test refinements

e2e tests are failing due to parallel execution using the same set of CDP API credentials, causing multiple transfers to execute concurrently raising nonce errors instead of waiting for the current transaction to complete.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
