### PR TITLE
Bug fix for non-checksummed address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CDP Python SDK Changelog
 
+## [0.16.0] - 2025-01-24
+
+### Fixed
+
+- Fixed a bug where non-checksummed asset IDs were throwing an error.
+
 ## [0.15.0] - 2025-01-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CDP Python SDK Changelog
 
-## [0.16.0] - 2025-01-24
+## Unreleased
 
 ### Fixed
 

--- a/cdp/asset.py
+++ b/cdp/asset.py
@@ -41,14 +41,18 @@ class Asset:
         """
         decimals = model.decimals
 
-        if asset_id and asset_id != model.asset_id:
-            match asset_id:
-                case "gwei":
-                    decimals = GWEI_DECIMALS
-                case "wei":
-                    decimals = 0
-                case _:
-                    raise ValueError(f"Unsupported asset ID: {asset_id}")
+        if asset_id and model.asset_id:
+            normalized_asset_id = asset_id.lower()
+            normalized_model_asset_id = model.asset_id.lower()
+
+            if normalized_asset_id != normalized_model_asset_id:
+                match normalized_asset_id:
+                    case "gwei":
+                        decimals = GWEI_DECIMALS
+                    case "wei":
+                        decimals = 0
+                    case _:
+                        raise ValueError(f"Unsupported asset ID: {asset_id}")
 
         return cls(
             network_id=model.network_id,

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -52,6 +52,22 @@ def test_asset_from_model_with_invalid_asset_id(asset_model_factory):
     with pytest.raises(ValueError, match="Unsupported asset ID: invalid"):
         Asset.from_model(asset_model, asset_id="invalid")
 
+def test_asset_from_model_with_non_checksummed_address(asset_model_factory):
+    """Test asset from model with non-checksummed address."""
+    asset_model = asset_model_factory(asset_id="0x8309fbdF021eDF768DC13195741940ba544dEa98", decimals=18)
+
+    asset = Asset.from_model(asset_model, asset_id="0x8309fbdf021edf768dc13195741940ba544dea98")
+    assert asset.asset_id == "0x8309fbdf021edf768dc13195741940ba544dea98"
+    assert asset.decimals == 18
+
+def test_asset_from_model_with_checksummed_address(asset_model_factory):
+    """Test asset from model with checksummed address."""
+    asset_model = asset_model_factory(asset_id="0x8309fbdF021eDF768DC13195741940ba544dEa98", decimals=18)
+
+    asset = Asset.from_model(asset_model, asset_id="0x8309fbdF021eDF768DC13195741940ba544dEa98")
+    assert asset.asset_id == "0x8309fbdF021eDF768DC13195741940ba544dEa98"
+    assert asset.decimals == 18
+
 
 @patch("cdp.Cdp.api_clients")
 def test_asset_fetch(mock_api_clients, asset_model_factory):


### PR DESCRIPTION
### What changed? Why?
There was a bug in the from_model function in asset.py. On the backend side, any asset id is checksummed before retrieving its details, and when it returns a response to the SDK, its asset id is also checksummed. When a user enters a non-checksummed address, they will get an error since those two asset ids are not equivalent.

This change will allow users to use non-checksummed addresses without getting erroneous errors in their workflow.

Before:
```
>>> wallet.balance('0x8309fbdf021edf768dc13195741940ba544dea98')

ValueError: Unsupported asset ID: 0x8309fbdf021edf768dc13195741940ba544dea98
```

Now:
```
>>> wallet.balance('0x8309fbdf021edf768dc13195741940ba544dea98')

Decimal('0')
```

#### Qualified Impact
This change should not be a breaking change for the SDK. The same logic of the check for asset ids exists, but with the normalization of cases, it prevents the bug of non-checksummed addresses and checksummed addresses being considered as unequal.
