### PR TITLE
chore: added USDC gasless transfer e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add E2E test for gasless transfers `Wallet.createTransfer({..., gasless: true})`
+
 ### Fixed
 
 - Fixed a bug where non-checksummed asset IDs were throwing an error.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -20,8 +20,6 @@ def configure_cdp():
     Cdp.configure(
         api_key_name=os.environ["CDP_API_KEY_NAME"],
         private_key=os.environ["CDP_API_KEY_PRIVATE_KEY"].replace("\\n", "\n"),
-        debugging=True,
-        base_path="https://cloud-api-dev.cbhq.net/platform/"
     )
 
 


### PR DESCRIPTION
### What changed? Why?
A Gasless transfer test was added for E2E tests. This test improves coverage for the gasless transfer feature, by ensuring the SDK can make gasless transfers for USDC over Base Sepolia.

#### Qualified Impact
This change will impact the E2E tests, which currently run in our CI/CD pipeline for Github PRs. The wallet data that is used for transferring USDC over Base Sepolia will need to be funded in case in runs out of funds for the test to pass.