### PR TITLE
Improve error message when SDK is used and not initialized

### DIFF
--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -30,12 +30,13 @@ class Cdp:
     debugging = False
     base_path = "https://api.cdp.coinbase.com/platform"
     max_network_retries = 3
-    
+
     class ApiClientsWrapper:
         """Wrapper that raises a helpful error when SDK is not initialized."""
+
         def __getattr__(self, _name):
             raise UninitializedSDKError()
-    
+
     api_clients = ApiClientsWrapper()
 
     def __new__(cls):

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -5,7 +5,7 @@ from cdp import __version__
 from cdp.api_clients import ApiClients
 from cdp.cdp_api_client import CdpApiClient
 from cdp.constants import SDK_DEFAULT_SOURCE
-from cdp.errors import InvalidConfigurationError
+from cdp.errors import InvalidConfigurationError, UninitializedSDKError
 
 
 class Cdp:
@@ -18,7 +18,7 @@ class Cdp:
         debugging (bool): Whether debugging is enabled.
         base_path (str): The base URL for the Platform API.
         max_network_retries (int): The maximum number of network retries.
-        api_clients (Optional[ApiClients]): The Platform API clients instance.
+        api_clients: The Platform API clients instance.
 
     """
 
@@ -30,7 +30,13 @@ class Cdp:
     debugging = False
     base_path = "https://api.cdp.coinbase.com/platform"
     max_network_retries = 3
-    api_clients: ApiClients | None = None
+    
+    class ApiClientsWrapper:
+        """Wrapper that raises a helpful error when SDK is not initialized."""
+        def __getattr__(self, _name):
+            raise UninitializedSDKError()
+    
+    api_clients = ApiClientsWrapper()
 
     def __new__(cls):
         """Create or return the singleton instance of the Cdp class.
@@ -88,6 +94,7 @@ class Cdp:
             source,
             source_version,
         )
+        # Replace the wrapper with the real api_clients instance
         cls.api_clients = ApiClients(cdp_client)
 
     @classmethod

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -95,7 +95,6 @@ class Cdp:
             source,
             source_version,
         )
-        # Replace the wrapper with the real api_clients instance
         cls.api_clients = ApiClients(cdp_client)
 
     @classmethod

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -35,6 +35,7 @@ class Cdp:
         """Wrapper that raises a helpful error when SDK is not initialized."""
 
         def __getattr__(self, _name):
+            """Raise an error when accessing an attribute of the ApiClientsWrapper."""
             raise UninitializedSDKError()
 
     api_clients = ApiClientsWrapper()

--- a/cdp/errors.py
+++ b/cdp/errors.py
@@ -4,6 +4,19 @@ from decimal import Decimal
 from cdp.client.exceptions import ApiException
 
 
+class UninitializedSDKError(Exception):
+    """Exception raised when trying to access CDP API clients before SDK initialization."""
+    
+    def __init__(self):
+        message = (
+            "Coinbase SDK has not been initialized. Please initialize by calling either:\n\n" +
+            "- Cdp.configure(api_key_name='...', private_key='...')\n"
+            "- Cdp.configure_from_json(file_path='/path/to/api_keys.json')\n\n"
+            "If needed, register for API keys at https://portal.cdp.coinbase.com/ or view the docs at https://docs.cdp.coinbase.com/wallet-api/docs/welcome"
+        )
+        super().__init__(message)
+        
+
 class ApiError(Exception):
     """A wrapper for API exceptions to provide more context."""
 

--- a/cdp/errors.py
+++ b/cdp/errors.py
@@ -6,16 +6,16 @@ from cdp.client.exceptions import ApiException
 
 class UninitializedSDKError(Exception):
     """Exception raised when trying to access CDP API clients before SDK initialization."""
-    
+
     def __init__(self):
         message = (
-            "Coinbase SDK has not been initialized. Please initialize by calling either:\n\n" +
-            "- Cdp.configure(api_key_name='...', private_key='...')\n"
+            "Coinbase SDK has not been initialized. Please initialize by calling either:\n\n"
+            + "- Cdp.configure(api_key_name='...', private_key='...')\n"
             "- Cdp.configure_from_json(file_path='/path/to/api_keys.json')\n\n"
             "If needed, register for API keys at https://portal.cdp.coinbase.com/ or view the docs at https://docs.cdp.coinbase.com/wallet-api/docs/welcome"
         )
         super().__init__(message)
-        
+
 
 class ApiError(Exception):
     """A wrapper for API exceptions to provide more context."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,11 @@ from cdp.api_clients import ApiClients
 @pytest.fixture(autouse=True)
 def initialize_cdp():
     """Initialize the CDP SDK with mock API clients before each test."""
+    original_api_clients = Cdp.api_clients
     mock_api_clients = MagicMock(spec=ApiClients)
     Cdp.api_clients = mock_api_clients
+    yield
+    Cdp.api_clients = original_api_clients
 
 
 factory_modules = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,11 @@ from cdp.api_clients import ApiClients
 @pytest.fixture(autouse=True)
 def initialize_cdp():
     """Initialize the CDP SDK with mock API clients before each test."""
+    # Skip this fixture for e2e tests
+    if request.node.get_closest_marker("e2e"):
+        yield
+        return
+
     original_api_clients = Cdp.api_clients
     mock_api_clients = MagicMock(spec=ApiClients)
     Cdp.api_clients = mock_api_clients

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,19 @@
 import os
 from unittest.mock import MagicMock
 
-from cdp import Cdp
 import pytest
 
+from cdp import Cdp
 from cdp.api_clients import ApiClients
+
 
 @pytest.fixture(autouse=True)
 def initialize_cdp():
     """Initialize the CDP SDK with mock API clients before each test."""
     mock_api_clients = MagicMock(spec=ApiClients)
     Cdp.api_clients = mock_api_clients
-    
 
-    
-    
+
 factory_modules = [
     f[:-3] for f in os.listdir("./tests/factories") if f.endswith(".py") and f != "__init__.py"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,20 @@
 import os
+from unittest.mock import MagicMock
 
+from cdp import Cdp
+import pytest
+
+from cdp.api_clients import ApiClients
+
+@pytest.fixture(autouse=True)
+def initialize_cdp():
+    """Initialize the CDP SDK with mock API clients before each test."""
+    mock_api_clients = MagicMock(spec=ApiClients)
+    Cdp.api_clients = mock_api_clients
+    
+
+    
+    
 factory_modules = [
     f[:-3] for f in os.listdir("./tests/factories") if f.endswith(".py") and f != "__init__.py"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from cdp.api_clients import ApiClients
 
 
 @pytest.fixture(autouse=True)
-def initialize_cdp():
+def initialize_cdp(request):
     """Initialize the CDP SDK with mock API clients before each test."""
     # Skip this fixture for e2e tests
     if request.node.get_closest_marker("e2e"):

--- a/tests/factories/api_key_factory.py
+++ b/tests/factories/api_key_factory.py
@@ -12,6 +12,7 @@ def dummy_key_factory():
       - "ed25519-32": Returns a base64-encoded 32-byte Ed25519 private key.
       - "ed25519-64": Returns a base64-encoded 64-byte dummy Ed25519 key (the first 32 bytes will be used).
     """
+
     def _create_dummy(key_type: str = "ecdsa") -> str:
         if key_type == "ecdsa":
             return (
@@ -25,9 +26,10 @@ def dummy_key_factory():
             return "BXyKC+eFINc/6ztE/3neSaPGgeiU9aDRpaDnAbaA/vyTrUNgtuh/1oX6Vp+OEObV3SLWF+OkF2EQNPtpl0pbfA=="
         elif key_type == "ed25519-64":
             # Create a 64-byte dummy by concatenating a 32-byte sequence with itself.
-            dummy_32 = b'\x01' * 32
+            dummy_32 = b"\x01" * 32
             dummy_64 = dummy_32 + dummy_32
             return base64.b64encode(dummy_64).decode("utf-8")
         else:
             raise ValueError("Unsupported key type for dummy key creation")
+
     return _create_dummy

--- a/tests/test_api_key_utils.py
+++ b/tests/test_api_key_utils.py
@@ -10,17 +10,20 @@ def test_parse_private_key_pem_ec(dummy_key_factory):
     parsed_key = _parse_private_key(dummy_key)
     assert isinstance(parsed_key, ec.EllipticCurvePrivateKey)
 
+
 def test_parse_private_key_ed25519_32(dummy_key_factory):
     """Test that a base64-encoded 32-byte Ed25519 key is parsed correctly using a dummy key from the factory."""
     dummy_key = dummy_key_factory("ed25519-32")
     parsed_key = _parse_private_key(dummy_key)
     assert isinstance(parsed_key, ed25519.Ed25519PrivateKey)
 
+
 def test_parse_private_key_ed25519_64(dummy_key_factory):
     """Test that a base64-encoded 64-byte input is parsed correctly by taking the first 32 bytes using a dummy key from the factory."""
     dummy_key = dummy_key_factory("ed25519-64")
     parsed_key = _parse_private_key(dummy_key)
     assert isinstance(parsed_key, ed25519.Ed25519PrivateKey)
+
 
 def test_parse_private_key_invalid():
     """Test that an invalid key string raises a ValueError."""

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from cdp import Cdp

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -1,0 +1,17 @@
+
+import pytest
+
+from cdp import Cdp
+from cdp.errors import UninitializedSDKError
+
+
+def test_uninitialized_error():
+    """Test that direct access to API clients raises UninitializedSDKError."""
+    Cdp.api_clients = Cdp.ApiClientsWrapper()
+
+    with pytest.raises(UninitializedSDKError) as excinfo:
+        Cdp.api_clients.wallets
+
+    assert "Coinbase SDK has not been initialized" in str(excinfo.value)
+    assert "Cdp.configure(api_key_name=" in str(excinfo.value)
+    assert "Cdp.configure_from_json(file_path=" in str(excinfo.value)

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -9,7 +9,7 @@ def test_uninitialized_error():
     Cdp.api_clients = Cdp.ApiClientsWrapper()
 
     with pytest.raises(UninitializedSDKError) as excinfo:
-        Cdp.api_clients.wallets
+        _ = Cdp.api_clients.wallets
 
     assert "Coinbase SDK has not been initialized" in str(excinfo.value)
     assert "Cdp.configure(api_key_name=" in str(excinfo.value)


### PR DESCRIPTION
### What changed? Why?
- Right now when a user forgets to call Coinbase.configure, they see an unclear error message because the apiClients aren't defined. This PR uses the proxy pattern in javascript to intercept getting the apiClients, and returns a clear message to the user.

### Notes to reviewers
Formatting/linting fixed a few unrelated test files so they can be ignored.

### Testing
- Added a unit test to confirm error behavior when not initialized. Updated conftest for global test setup to mock the APIClients - this was needed for all existing tests to succeed with the new behavior.
- E2E testing, both with and without Coinbase.configure, have expected behavior.

Here's how it looks:
```
❯ python test_smart_wallet.py 
Traceback (most recent call last):
  File "/Users/rohanagarwal/code/cdp-sdk-python/test_smart_wallet.py", line 68, in <module>
    test_smart_wallet_operations()
  File "/Users/rohanagarwal/code/cdp-sdk-python/test_smart_wallet.py", line 15, in test_smart_wallet_operations
    smart_wallet = SmartWallet.create(account=owner)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rohanagarwal/code/cdp-sdk-python/cdp/smart_wallet.py", line 61, in create
    model = Cdp.api_clients.smart_wallets.create_smart_wallet(create_smart_wallet_request)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rohanagarwal/code/cdp-sdk-python/cdp/cdp.py", line 38, in __getattr__
    raise UninitializedSDKError()
cdp.errors.UninitializedSDKError: Coinbase SDK has not been initialized. Please initialize by calling either:

- Cdp.configure(api_key_name='...', private_key='...')
- Cdp.configure_from_json(file_path='/path/to/api_keys.json')

If needed, register for API keys at https://portal.cdp.coinbase.com/ or view the docs at https://docs.cdp.coinbase.com/wallet-api/docs/welcome
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
