### PR TITLE
Update UserOperation status to support string comparison

### DIFF
--- a/cdp/user_operation.py
+++ b/cdp/user_operation.py
@@ -48,7 +48,7 @@ class UserOperation:
             return super().__eq__(other)
 
         def __hash__(self):
-            """Preserve hashability for dictionary keys."""
+            """Return a hash value for the enum member to allow use as dictionary keys."""
             return hash(self.name)
 
     def __init__(self, model: UserOperationModel, smart_wallet_address: str) -> None:

--- a/cdp/user_operation.py
+++ b/cdp/user_operation.py
@@ -41,6 +41,11 @@ class UserOperation:
             """Return a string representation of the Status."""
             return str(self)
 
+        def __eq__(self, other):
+            if isinstance(other, str):
+                return self.value == other
+            return super().__eq__(other)
+
     def __init__(self, model: UserOperationModel, smart_wallet_address: str) -> None:
         """Initialize the UserOperation class.
 

--- a/cdp/user_operation.py
+++ b/cdp/user_operation.py
@@ -42,6 +42,7 @@ class UserOperation:
             return str(self)
 
         def __eq__(self, other):
+            """Check if the status is equal to another object. Supports string comparison."""
             if isinstance(other, str):
                 return self.value == other
             return super().__eq__(other)

--- a/cdp/user_operation.py
+++ b/cdp/user_operation.py
@@ -46,6 +46,10 @@ class UserOperation:
                 return self.value == other
             return super().__eq__(other)
 
+        def __hash__(self):
+            """Preserve hashability for dictionary keys."""
+            return hash(self.name)
+
     def __init__(self, model: UserOperationModel, smart_wallet_address: str) -> None:
         """Initialize the UserOperation class.
 

--- a/tests/factories/api_key_factory.py
+++ b/tests/factories/api_key_factory.py
@@ -12,6 +12,7 @@ def dummy_key_factory():
       - "ed25519-32": Returns a base64-encoded 32-byte Ed25519 private key.
       - "ed25519-64": Returns a base64-encoded 64-byte dummy Ed25519 key (the first 32 bytes will be used).
     """
+
     def _create_dummy(key_type: str = "ecdsa") -> str:
         if key_type == "ecdsa":
             return (
@@ -25,9 +26,10 @@ def dummy_key_factory():
             return "BXyKC+eFINc/6ztE/3neSaPGgeiU9aDRpaDnAbaA/vyTrUNgtuh/1oX6Vp+OEObV3SLWF+OkF2EQNPtpl0pbfA=="
         elif key_type == "ed25519-64":
             # Create a 64-byte dummy by concatenating a 32-byte sequence with itself.
-            dummy_32 = b'\x01' * 32
+            dummy_32 = b"\x01" * 32
             dummy_64 = dummy_32 + dummy_32
             return base64.b64encode(dummy_64).decode("utf-8")
         else:
             raise ValueError("Unsupported key type for dummy key creation")
+
     return _create_dummy

--- a/tests/test_api_key_utils.py
+++ b/tests/test_api_key_utils.py
@@ -10,17 +10,20 @@ def test_parse_private_key_pem_ec(dummy_key_factory):
     parsed_key = _parse_private_key(dummy_key)
     assert isinstance(parsed_key, ec.EllipticCurvePrivateKey)
 
+
 def test_parse_private_key_ed25519_32(dummy_key_factory):
     """Test that a base64-encoded 32-byte Ed25519 key is parsed correctly using a dummy key from the factory."""
     dummy_key = dummy_key_factory("ed25519-32")
     parsed_key = _parse_private_key(dummy_key)
     assert isinstance(parsed_key, ed25519.Ed25519PrivateKey)
 
+
 def test_parse_private_key_ed25519_64(dummy_key_factory):
     """Test that a base64-encoded 64-byte input is parsed correctly by taking the first 32 bytes using a dummy key from the factory."""
     dummy_key = dummy_key_factory("ed25519-64")
     parsed_key = _parse_private_key(dummy_key)
     assert isinstance(parsed_key, ed25519.Ed25519PrivateKey)
+
 
 def test_parse_private_key_invalid():
     """Test that an invalid key string raises a ValueError."""

--- a/tests/test_user_operation.py
+++ b/tests/test_user_operation.py
@@ -29,6 +29,21 @@ def test_user_operation_properties(user_operation_model_factory):
     assert user_operation.transaction_hash == model.transaction_hash
 
 
+def test_user_operation_status_comparison():
+    """Test the comparison of UserOperation statuses."""
+    expected_statuses = {
+        UserOperation.Status.PENDING: "pending",
+        UserOperation.Status.SIGNED: "signed",
+        UserOperation.Status.BROADCAST: "broadcast",
+        UserOperation.Status.COMPLETE: "complete",
+        UserOperation.Status.FAILED: "failed",
+        UserOperation.Status.UNSPECIFIED: "unspecified",
+    }
+
+    for status, _ in expected_statuses.items():
+        assert status == expected_statuses[status]
+
+
 @patch("cdp.Cdp.api_clients")
 def test_create_user_operation(mock_api_clients, user_operation_model_factory):
     """Test the creation of a UserOperation object."""

--- a/tests/test_user_operation.py
+++ b/tests/test_user_operation.py
@@ -29,21 +29,6 @@ def test_user_operation_properties(user_operation_model_factory):
     assert user_operation.transaction_hash == model.transaction_hash
 
 
-def test_user_operation_status_comparison():
-    """Test the comparison of UserOperation statuses."""
-    expected_statuses = {
-        UserOperation.Status.PENDING: "pending",
-        UserOperation.Status.SIGNED: "signed",
-        UserOperation.Status.BROADCAST: "broadcast",
-        UserOperation.Status.COMPLETE: "complete",
-        UserOperation.Status.FAILED: "failed",
-        UserOperation.Status.UNSPECIFIED: "unspecified",
-    }
-
-    for status, _ in expected_statuses.items():
-        assert status == expected_statuses[status]
-
-
 @patch("cdp.Cdp.api_clients")
 def test_create_user_operation(mock_api_clients, user_operation_model_factory):
     """Test the creation of a UserOperation object."""


### PR DESCRIPTION
### What changed? Why?
- @CarsonRoscoe discovered that doing userOperation.status == 'complete' doesn't work since it's an enum. This PR makes it possible to do a string comparison

### Testing
- Added unit test that succeeds after these code changes
- Tested E2E to see that string comparison work
